### PR TITLE
fix duplicate_rule stderr mismatch

### DIFF
--- a/garde_derive_tests/tests/compile-fail/duplicate_rule.stderr
+++ b/garde_derive_tests/tests/compile-fail/duplicate_rule.stderr
@@ -2,4 +2,4 @@ error: duplicate rule `ascii`
  --> tests/compile-fail/duplicate_rule.rs:3:7
   |
 3 |     #[garde(ascii, ascii)]
-  |       ^^^^^^^^^^^^^^^^^^^
+  |       ^^^^^


### PR DESCRIPTION
This commit will fix the `stderr` mistach from `compile-fail/duplicate_rule.rs`.