### PR TITLE
Implement nested validation and nested errors

### DIFF
--- a/garde/src/error.rs
+++ b/garde/src/error.rs
@@ -8,8 +8,10 @@ pub struct Error {
 }
 
 impl Error {
-    pub fn new(message: Cow<'static, str>) -> Self {
-        Self { message }
+    pub fn new(message: impl Into<Cow<'static, str>>) -> Self {
+        Self {
+            message: message.into(),
+        }
     }
 }
 
@@ -21,45 +23,182 @@ impl std::fmt::Display for Error {
 
 impl std::error::Error for Error {}
 
-/// This type encapsulates a set of validation errors.
+/// This type encapsulates a set of (potentially nested) validation errors.
 #[derive(Clone, Debug)]
-pub struct Errors {
-    pub fields: BTreeMap<&'static str, Vec<Error>>,
+pub enum Errors {
+    Simple(Vec<Error>),
+    List(Vec<Errors>),
+    Fields(BTreeMap<&'static str, Errors>),
 }
 
 impl Errors {
-    pub fn new() -> Self {
-        Self {
-            fields: BTreeMap::new(),
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Errors::Simple(v) => v.is_empty(),
+            Errors::List(v) => v.is_empty(),
+            Errors::Fields(v) => v.is_empty(),
         }
     }
 
-    pub fn is_empty(&self) -> bool {
-        self.fields.is_empty()
+    pub fn flatten(self) -> Vec<(String, Error)> {
+        fn flatten_inner(out: &mut Vec<(String, Error)>, current_path: String, errors: &Errors) {
+            match errors {
+                Errors::Simple(errors) => {
+                    for error in errors {
+                        out.push((current_path.clone(), error.clone()));
+                    }
+                }
+                Errors::List(errors) => {
+                    for (i, errors) in errors.iter().enumerate() {
+                        flatten_inner(out, format!("{current_path}[{i}]"), errors);
+                    }
+                }
+                Errors::Fields(errors) => {
+                    for (key, errors) in errors.iter() {
+                        flatten_inner(out, format!("{current_path}.{key}"), errors);
+                    }
+                }
+            }
+        }
+
+        let mut errors = vec![];
+        flatten_inner(&mut errors, "value".to_string(), &self);
+        errors
     }
 
-    pub fn insert(&mut self, key: &'static str, err: Error) {
-        self.fields.entry(key).or_insert(vec![]).push(err);
+    pub fn empty() -> Self {
+        Errors::Simple(Vec::new())
+    }
+
+    pub fn simple<F>(f: F) -> Errors
+    where
+        F: FnMut(&mut SimpleErrorBuilder),
+    {
+        SimpleErrorBuilder::dive(f)
+    }
+
+    pub fn list<F>(f: F) -> Errors
+    where
+        F: FnMut(&mut ListErrorBuilder),
+    {
+        ListErrorBuilder::dive(f)
+    }
+
+    pub fn fields<F>(f: F) -> Errors
+    where
+        F: FnMut(&mut FieldsErrorBuilder),
+    {
+        FieldsErrorBuilder::dive(f)
     }
 }
 
-impl Default for Errors {
-    fn default() -> Self {
-        Self::new()
+// TODO: remove rename, change rules to not require field_name
+
+#[doc(hidden)]
+pub struct SimpleErrorBuilder {
+    inner: Vec<Error>,
+}
+
+impl SimpleErrorBuilder {
+    fn dive<F>(mut f: F) -> Errors
+    where
+        F: FnMut(&mut SimpleErrorBuilder),
+    {
+        let mut builder = SimpleErrorBuilder { inner: Vec::new() };
+        f(&mut builder);
+        Errors::Simple(builder.inner)
+    }
+
+    pub fn push(&mut self, error: Error) {
+        self.inner.push(error);
+    }
+}
+
+#[doc(hidden)]
+pub struct ListErrorBuilder {
+    inner: Vec<Errors>,
+}
+
+impl ListErrorBuilder {
+    fn dive<F>(mut f: F) -> Errors
+    where
+        F: FnMut(&mut ListErrorBuilder),
+    {
+        let mut builder = ListErrorBuilder { inner: Vec::new() };
+        f(&mut builder);
+        Errors::List(builder.inner)
+    }
+
+    pub fn push(&mut self, entry: Errors) {
+        if entry.is_empty() {
+            return;
+        }
+
+        self.inner.push(entry);
+    }
+}
+
+#[doc(hidden)]
+pub struct FieldsErrorBuilder {
+    inner: BTreeMap<&'static str, Errors>,
+}
+
+impl FieldsErrorBuilder {
+    fn dive<F>(mut f: F) -> Errors
+    where
+        F: FnMut(&mut FieldsErrorBuilder),
+    {
+        let mut builder = FieldsErrorBuilder {
+            inner: BTreeMap::new(),
+        };
+        f(&mut builder);
+        Errors::Fields(builder.inner)
+    }
+
+    pub fn insert(&mut self, field: &'static str, entry: Errors) {
+        if entry.is_empty() {
+            return;
+        }
+
+        let existing = self.inner.insert(field, entry);
+        assert!(
+            existing.is_none(),
+            "each field should only be dived into once"
+        )
     }
 }
 
 impl std::fmt::Display for Errors {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        for errors in self.fields.values() {
-            let mut iter = errors.iter().peekable();
-            while let Some(error) = iter.next() {
-                write!(f, "{error}")?;
-                if iter.peek().is_some() {
-                    writeln!(f)?;
+        match self {
+            Errors::Simple(v) => {
+                let mut iter = v.iter().peekable();
+                while let Some(error) = iter.next() {
+                    write!(f, "{error}")?;
+                    if iter.peek().is_some() {
+                        writeln!(f)?;
+                    }
                 }
             }
-        }
+            Errors::List(v) => {
+                let mut iter = v.iter().peekable();
+                while let Some(error) = iter.next() {
+                    write!(f, "{error}")?;
+                    if iter.peek().is_some() {
+                        writeln!(f)?;
+                    }
+                }
+            }
+            Errors::Fields(v) => {
+                let mut iter = v.values().peekable();
+                while let Some(error) = iter.next() {
+                    write!(f, "{error}")?;
+                    if iter.peek().is_some() {
+                        writeln!(f)?;
+                    }
+                }
+            }
+        };
         Ok(())
     }
 }

--- a/garde/src/rules/alphanumeric.rs
+++ b/garde/src/rules/alphanumeric.rs
@@ -1,10 +1,8 @@
 use crate::error::Error;
 
-pub fn apply<T: Alphanumeric>(field_name: &str, v: &T) -> Result<(), Error> {
+pub fn apply<T: Alphanumeric>(v: &T, _: ()) -> Result<(), Error> {
     if !v.check_alphanumeric() {
-        return Err(Error::new(
-            format!("`{field_name}` is not alphanumeric").into(),
-        ));
+        return Err(Error::new("not alphanumeric"));
     }
     Ok(())
 }

--- a/garde/src/rules/ascii.rs
+++ b/garde/src/rules/ascii.rs
@@ -1,8 +1,8 @@
 use crate::error::Error;
 
-pub fn apply<T: Ascii>(field_name: &str, v: &T) -> Result<(), Error> {
+pub fn apply<T: Ascii>(v: &T, _: ()) -> Result<(), Error> {
     if !v.check_ascii() {
-        return Err(Error::new(format!("`{field_name}` is not ascii").into()));
+        return Err(Error::new("not ascii"));
     }
     Ok(())
 }

--- a/garde/src/rules/contains.rs
+++ b/garde/src/rules/contains.rs
@@ -1,10 +1,8 @@
 use crate::error::Error;
 
-pub fn apply<T: Contains>(field_name: &str, v: &T, pat: &str) -> Result<(), Error> {
+pub fn apply<T: Contains>(v: &T, (pat,): (&str,)) -> Result<(), Error> {
     if !v.check_contains(pat) {
-        return Err(Error::new(
-            format!("`{field_name}` does not contain \"{pat}\"").into(),
-        ));
+        return Err(Error::new(format!("does not contain \"{pat}\"")));
     }
     Ok(())
 }

--- a/garde/src/rules/credit_card.rs
+++ b/garde/src/rules/credit_card.rs
@@ -2,11 +2,9 @@ use std::fmt::Display;
 
 use crate::error::Error;
 
-pub fn apply<T: CreditCard>(field_name: &str, v: &T) -> Result<(), Error> {
+pub fn apply<T: CreditCard>(v: &T, _: ()) -> Result<(), Error> {
     if let Err(e) = v.try_parse_credit_card() {
-        return Err(Error::new(
-            format!("`{field_name}` is not a valid credit card number: {e}").into(),
-        ));
+        return Err(Error::new(format!("not a valid credit card number: {e}")));
     }
     Ok(())
 }

--- a/garde/src/rules/email.rs
+++ b/garde/src/rules/email.rs
@@ -6,11 +6,9 @@ use regex::Regex;
 
 use crate::error::Error;
 
-pub fn apply<T: Email>(field_name: &str, v: &T) -> Result<(), Error> {
+pub fn apply<T: Email>(v: &T, _: ()) -> Result<(), Error> {
     if let Err(e) = v.try_parse_email() {
-        return Err(Error::new(
-            format!("`{field_name}` is not a valid email: {e}").into(),
-        ));
+        return Err(Error::new(format!("not a valid email: {e}")));
     }
     Ok(())
 }

--- a/garde/src/rules/ip.rs
+++ b/garde/src/rules/ip.rs
@@ -3,11 +3,9 @@ use std::str::FromStr;
 
 use crate::error::Error;
 
-pub fn apply<T: Ip>(field_name: &str, v: &T, kind: IpKind) -> Result<(), Error> {
+pub fn apply<T: Ip>(v: &T, (kind,): (IpKind,)) -> Result<(), Error> {
     if v.try_parse_ip(kind).is_err() {
-        return Err(Error::new(
-            format!("`{field_name}` is not a valid {kind} address").into(),
-        ));
+        return Err(Error::new(format!("not a valid {kind} address")));
     }
     Ok(())
 }

--- a/garde/src/rules/length.rs
+++ b/garde/src/rules/length.rs
@@ -1,18 +1,10 @@
 use crate::error::Error;
 
-pub fn apply<T: Length>(field_name: &str, v: &T, min: usize, max: usize) -> Result<(), Error> {
+pub fn apply<T: Length>(v: &T, (min, max): (usize, usize)) -> Result<(), Error> {
     if let Err(e) = v.check_length(min, max) {
         match e {
-            InvalidLength::Min => {
-                return Err(Error::new(
-                    format!("length of `{field_name}` is less than {min}").into(),
-                ))
-            }
-            InvalidLength::Max => {
-                return Err(Error::new(
-                    format!("length of `{field_name}` is greater than {max}").into(),
-                ))
-            }
+            InvalidLength::Min => return Err(Error::new(format!("length is lower than {min}"))),
+            InvalidLength::Max => return Err(Error::new(format!("length is greater than {max}"))),
         }
     }
     Ok(())

--- a/garde/src/rules/pattern.rs
+++ b/garde/src/rules/pattern.rs
@@ -1,10 +1,8 @@
 use crate::error::Error;
 
-pub fn apply<T: Pattern>(field_name: &str, v: &T, pat: &regex::Regex) -> Result<(), Error> {
+pub fn apply<T: Pattern>(v: &T, (pat,): (&regex::Regex,)) -> Result<(), Error> {
     if !v.matches(pat) {
-        return Err(Error::new(
-            format!("`{field_name}` does not match pattern /{pat}/").into(),
-        ));
+        return Err(Error::new(format!("does not match pattern /{pat}/")));
     }
     Ok(())
 }

--- a/garde/src/rules/phone_number.rs
+++ b/garde/src/rules/phone_number.rs
@@ -16,11 +16,9 @@ pub trait PhoneNumber {
     fn try_parse_phone_number(&self) -> Result<(), Self::Error>;
 }
 
-pub fn apply<T: PhoneNumber>(field_name: &str, v: &T) -> Result<(), Error> {
+pub fn apply<T: PhoneNumber>(v: &T, _: ()) -> Result<(), Error> {
     if let Err(e) = v.try_parse_phone_number() {
-        return Err(Error::new(
-            format!("`{field_name}` is not a valid phone number: {e}").into(),
-        ));
+        return Err(Error::new(format!("not a valid phone number: {e}")));
     }
     Ok(())
 }

--- a/garde/src/rules/prefix.rs
+++ b/garde/src/rules/prefix.rs
@@ -11,11 +11,9 @@ pub trait Prefix {
     fn has_prefix(&self, pat: &str) -> bool;
 }
 
-pub fn apply<T: Prefix>(field_name: &str, v: &T, pat: &str) -> Result<(), Error> {
+pub fn apply<T: Prefix>(v: &T, (pat,): (&str,)) -> Result<(), Error> {
     if !v.has_prefix(pat) {
-        return Err(Error::new(
-            format!("`{field_name}` does not begin with \"{pat}\"").into(),
-        ));
+        return Err(Error::new(format!("value does not begin with \"{pat}\"")));
     }
     Ok(())
 }

--- a/garde/src/rules/range.rs
+++ b/garde/src/rules/range.rs
@@ -1,18 +1,12 @@
+use std::fmt::Display;
+
 use crate::error::Error;
 
-pub fn apply<T: Bounds>(field_name: &str, v: &T, min: &T, max: &T) -> Result<(), Error> {
+pub fn apply<T: Bounds>(v: &T, (min, max): (&T, &T)) -> Result<(), Error> {
     if let Err(e) = v.check_bounds(min, max) {
         match e {
-            OutOfBounds::Lower => {
-                return Err(Error::new(
-                    format!("`{field_name}` is out of bounds").into(),
-                ))
-            }
-            OutOfBounds::Upper => {
-                return Err(Error::new(
-                    format!("`{field_name}` is out of bounds").into(),
-                ))
-            }
+            OutOfBounds::Lower => return Err(Error::new(format!("lower than {min}"))),
+            OutOfBounds::Upper => return Err(Error::new(format!("greater than {max}"))),
         }
     }
     Ok(())
@@ -26,7 +20,7 @@ pub fn apply<T: Bounds>(field_name: &str, v: &T, min: &T, max: &T) -> Result<(),
         note = "try implementing `garde::rules::range::Bounds` for `{Self}`"
     )
 )]
-pub trait Bounds: PartialOrd {
+pub trait Bounds: PartialOrd + Display {
     const MIN: Self;
     const MAX: Self;
     fn check_bounds(&self, lower_bound: &Self, upper_bound: &Self) -> Result<(), OutOfBounds>;

--- a/garde/src/rules/suffix.rs
+++ b/garde/src/rules/suffix.rs
@@ -11,11 +11,9 @@ pub trait Suffix {
     fn has_suffix(&self, pat: &str) -> bool;
 }
 
-pub fn apply<T: Suffix>(field_name: &str, v: &T, pat: &str) -> Result<(), Error> {
+pub fn apply<T: Suffix>(v: &T, (pat,): (&str,)) -> Result<(), Error> {
     if !v.has_suffix(pat) {
-        return Err(Error::new(
-            format!("{field_name} does not end with \"{pat}\"").into(),
-        ));
+        return Err(Error::new(format!("does not end with \"{pat}\"")));
     }
     Ok(())
 }

--- a/garde/src/rules/url.rs
+++ b/garde/src/rules/url.rs
@@ -2,11 +2,9 @@ use std::fmt::Display;
 
 use crate::error::Error;
 
-pub fn apply<T: Url>(field_name: &str, v: &T) -> Result<(), Error> {
+pub fn apply<T: Url>(v: &T, _: ()) -> Result<(), Error> {
     if let Err(e) = v.try_parse_url() {
-        return Err(Error::new(
-            format!("`{field_name}` is not a valid url: {e}").into(),
-        ));
+        return Err(Error::new(format!("not a valid url: {e}")));
     }
     Ok(())
 }

--- a/garde_derive_tests/tests/compile-fail/dive_with_rules.rs
+++ b/garde_derive_tests/tests/compile-fail/dive_with_rules.rs
@@ -1,0 +1,13 @@
+#[derive(Debug, garde::Validate)]
+struct Inner<'a> {
+    #[garde(length(min = 1))]
+    field: &'a str,
+}
+
+#[derive(Debug, garde::Validate)]
+struct Test<'a> {
+    #[garde(dive, length(min = 1))]
+    field: Inner<'a>,
+}
+
+fn main() {}

--- a/garde_derive_tests/tests/compile-fail/dive_with_rules.stderr
+++ b/garde_derive_tests/tests/compile-fail/dive_with_rules.stderr
@@ -1,0 +1,5 @@
+error: `length` may not be used together with `dive`
+ --> tests/compile-fail/dive_with_rules.rs:9:7
+  |
+9 |     #[garde(dive, length(min = 1))]
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/garde_derive_tests/tests/compile-pass/custom.rs
+++ b/garde_derive_tests/tests/compile-pass/custom.rs
@@ -2,11 +2,11 @@
 struct Test<'a> {
     #[garde(custom(custom_validate_fn))]
     a: &'a str,
-    #[garde(custom(|_, _, _| Ok(())))]
+    #[garde(custom(|_, _| Ok(())))]
     b: &'a str,
 }
 
-fn custom_validate_fn(_: &str, _: &str, _: &()) -> Result<(), garde::Error> {
+fn custom_validate_fn(_: &str, _: &()) -> Result<(), garde::Error> {
     unimplemented!()
 }
 

--- a/garde_derive_tests/tests/custom.rs
+++ b/garde_derive_tests/tests/custom.rs
@@ -10,24 +10,18 @@ struct Context<'a> {
 struct Test<'a> {
     #[garde(custom(custom_validate_fn))]
     a: &'a str,
-    #[garde(custom(|_, value: &str, ctx: &Context<'a>| {
+    #[garde(custom(|value: &str, ctx: &Context<'a>| {
         if value != ctx.needle {
-            return Err(garde::Error::new(format!("`b` is not equal to {}", ctx.needle).into()));
+            return Err(garde::Error::new(format!("`b` is not equal to {}", ctx.needle)));
         }
         Ok(())
     }))]
     b: &'a str,
 }
 
-fn custom_validate_fn(
-    field_name: &str,
-    value: &str,
-    ctx: &Context<'_>,
-) -> Result<(), garde::Error> {
+fn custom_validate_fn(value: &str, ctx: &Context<'_>) -> Result<(), garde::Error> {
     if value != ctx.needle {
-        return Err(garde::Error::new(
-            format!("`{field_name}` is not equal to {}", ctx.needle).into(),
-        ));
+        return Err(garde::Error::new(format!("not equal to {}", ctx.needle)));
     }
     Ok(())
 }

--- a/garde_derive_tests/tests/dive.rs
+++ b/garde_derive_tests/tests/dive.rs
@@ -1,0 +1,34 @@
+#[path = "./util/mod.rs"]
+mod util;
+
+#[derive(Debug, garde::Validate)]
+struct Inner<'a> {
+    #[garde(length(min = 1))]
+    field: &'a str,
+}
+
+#[derive(Debug, garde::Validate)]
+struct Test<'a> {
+    #[garde(dive)]
+    field: Inner<'a>,
+}
+
+#[test]
+fn email_valid() {
+    util::check_ok(
+        &[Test {
+            field: Inner { field: "asdf" },
+        }],
+        &(),
+    )
+}
+
+#[test]
+fn email_invalid() {
+    util::check_fail!(
+        &[Test {
+            field: Inner { field: "" }
+        }],
+        &()
+    )
+}

--- a/garde_derive_tests/tests/snapshots/alphanumeric__alphanumeric_invalid.snap
+++ b/garde_derive_tests/tests/snapshots/alphanumeric__alphanumeric_invalid.snap
@@ -5,6 +5,6 @@ expression: snapshot
 Test {
     field: "!!!!",
 }
-`field` is not alphanumeric
+value.field: not alphanumeric
 
 

--- a/garde_derive_tests/tests/snapshots/ascii__ascii_invalid.snap
+++ b/garde_derive_tests/tests/snapshots/ascii__ascii_invalid.snap
@@ -5,6 +5,6 @@ expression: snapshot
 Test {
     field: "😂",
 }
-`field` is not ascii
+value.field: not ascii
 
 

--- a/garde_derive_tests/tests/snapshots/contains__contains_invalid.snap
+++ b/garde_derive_tests/tests/snapshots/contains__contains_invalid.snap
@@ -5,6 +5,6 @@ expression: snapshot
 Test {
     field: "_____",
 }
-`field` does not contain "test"
+value.field: does not contain "test"
 
 

--- a/garde_derive_tests/tests/snapshots/credit_card__credit_card_invalid.snap
+++ b/garde_derive_tests/tests/snapshots/credit_card__credit_card_invalid.snap
@@ -5,11 +5,11 @@ expression: snapshot
 Test {
     field: "zduhefljsdfKJKJZHUI",
 }
-`field` is not a valid credit card number: invalid format
+value.field: not a valid credit card number: invalid format
 
 Test {
     field: "5236313877109141",
 }
-`field` is not a valid credit card number: invalid luhn
+value.field: not a valid credit card number: invalid luhn
 
 

--- a/garde_derive_tests/tests/snapshots/custom__custom_invalid.snap
+++ b/garde_derive_tests/tests/snapshots/custom__custom_invalid.snap
@@ -6,6 +6,7 @@ Test {
     a: "asdf",
     b: "asdf",
 }
-`a` is not equal to test`b` is not equal to test
+value.a: not equal to test
+value.b: `b` is not equal to test
 
 

--- a/garde_derive_tests/tests/snapshots/dive__email_invalid.snap
+++ b/garde_derive_tests/tests/snapshots/dive__email_invalid.snap
@@ -1,0 +1,12 @@
+---
+source: garde_derive_tests/tests/dive.rs
+expression: snapshot
+---
+Test {
+    field: Inner {
+        field: "",
+    },
+}
+value.field.field: length is lower than 1
+
+

--- a/garde_derive_tests/tests/snapshots/email__email_invalid.snap
+++ b/garde_derive_tests/tests/snapshots/email__email_invalid.snap
@@ -5,6 +5,6 @@ expression: snapshot
 Test {
     field: "invalid.com",
 }
-`field` is not a valid email: value is missing `@`
+value.field: not a valid email: value is missing `@`
 
 

--- a/garde_derive_tests/tests/snapshots/ip__ip_any_invalid.snap
+++ b/garde_derive_tests/tests/snapshots/ip__ip_any_invalid.snap
@@ -5,21 +5,21 @@ expression: snapshot
 TestIpAny {
     field: "256.1.1.1",
 }
-`field` is not a valid IP address
+value.field: not a valid IP address
 
 TestIpAny {
     field: "25.1.1.",
 }
-`field` is not a valid IP address
+value.field: not a valid IP address
 
 TestIpAny {
     field: "25,1,1,1",
 }
-`field` is not a valid IP address
+value.field: not a valid IP address
 
 TestIpAny {
     field: "2a02::223:6cff :fe8a:2e8a",
 }
-`field` is not a valid IP address
+value.field: not a valid IP address
 
 

--- a/garde_derive_tests/tests/snapshots/ip__ip_v4_invalid.snap
+++ b/garde_derive_tests/tests/snapshots/ip__ip_v4_invalid.snap
@@ -5,31 +5,31 @@ expression: snapshot
 TestIpV4 {
     field: "256.1.1.1",
 }
-`field` is not a valid IPv4 address
+value.field: not a valid IPv4 address
 
 TestIpV4 {
     field: "25.1.1.",
 }
-`field` is not a valid IPv4 address
+value.field: not a valid IPv4 address
 
 TestIpV4 {
     field: "25,1,1,1",
 }
-`field` is not a valid IPv4 address
+value.field: not a valid IPv4 address
 
 TestIpV4 {
     field: "25.1 .1.1",
 }
-`field` is not a valid IPv4 address
+value.field: not a valid IPv4 address
 
 TestIpV4 {
     field: "1.1.1.1\n",
 }
-`field` is not a valid IPv4 address
+value.field: not a valid IPv4 address
 
 TestIpV4 {
     field: "٧.2٥.3٣.243",
 }
-`field` is not a valid IPv4 address
+value.field: not a valid IPv4 address
 
 

--- a/garde_derive_tests/tests/snapshots/ip__ip_v6_invalid.snap
+++ b/garde_derive_tests/tests/snapshots/ip__ip_v6_invalid.snap
@@ -5,51 +5,51 @@ expression: snapshot
 TestIpV6 {
     field: "foo",
 }
-`field` is not a valid IPv6 address
+value.field: not a valid IPv6 address
 
 TestIpV6 {
     field: "127.0.0.1",
 }
-`field` is not a valid IPv6 address
+value.field: not a valid IPv6 address
 
 TestIpV6 {
     field: "12345::",
 }
-`field` is not a valid IPv6 address
+value.field: not a valid IPv6 address
 
 TestIpV6 {
     field: "1::2::3::4",
 }
-`field` is not a valid IPv6 address
+value.field: not a valid IPv6 address
 
 TestIpV6 {
     field: "1::zzz",
 }
-`field` is not a valid IPv6 address
+value.field: not a valid IPv6 address
 
 TestIpV6 {
     field: "1:2",
 }
-`field` is not a valid IPv6 address
+value.field: not a valid IPv6 address
 
 TestIpV6 {
     field: "fe80::223: 6cff:fe8a:2e8a",
 }
-`field` is not a valid IPv6 address
+value.field: not a valid IPv6 address
 
 TestIpV6 {
     field: "2a02::223:6cff :fe8a:2e8a",
 }
-`field` is not a valid IPv6 address
+value.field: not a valid IPv6 address
 
 TestIpV6 {
     field: "::ffff:999.42.16.14",
 }
-`field` is not a valid IPv6 address
+value.field: not a valid IPv6 address
 
 TestIpV6 {
     field: "::ffff:zzzz:0a0a",
 }
-`field` is not a valid IPv6 address
+value.field: not a valid IPv6 address
 
 

--- a/garde_derive_tests/tests/snapshots/length__length_invalid.snap
+++ b/garde_derive_tests/tests/snapshots/length__length_invalid.snap
@@ -5,11 +5,11 @@ expression: snapshot
 Test {
     field: "aaaaaaaaa",
 }
-length of `field` is less than 10
+value.field: length is lower than 10
 
 Test {
     field: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 }
-length of `field` is greater than 100
+value.field: length is greater than 100
 
 

--- a/garde_derive_tests/tests/snapshots/multi_rule__multi_rule_invalid.snap
+++ b/garde_derive_tests/tests/snapshots/multi_rule__multi_rule_invalid.snap
@@ -5,24 +5,24 @@ expression: snapshot
 Test {
     field: "text which does not begin with `test`",
 }
-`field` does not begin with "test"
+value.field: value does not begin with "test"
 
 Test {
     field: "non-ascii 😂😂😂",
 }
-`field` is not ascii
-`field` does not begin with "test"
+value.field: not ascii
+value.field: value does not begin with "test"
 
 Test {
     field: "aaaaaaaaa",
 }
-length of `field` is less than 10
-`field` does not begin with "test"
+value.field: length is lower than 10
+value.field: value does not begin with "test"
 
 Test {
     field: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 }
-length of `field` is greater than 100
-`field` does not begin with "test"
+value.field: length is greater than 100
+value.field: value does not begin with "test"
 
 

--- a/garde_derive_tests/tests/snapshots/pattern__pattern_invalid.snap
+++ b/garde_derive_tests/tests/snapshots/pattern__pattern_invalid.snap
@@ -5,11 +5,11 @@ expression: snapshot
 Test {
     field: "dcba",
 }
-`field` does not match pattern /^abcd|efgh$/
+value.field: does not match pattern /^abcd|efgh$/
 
 Test {
     field: "hgfe",
 }
-`field` does not match pattern /^abcd|efgh$/
+value.field: does not match pattern /^abcd|efgh$/
 
 

--- a/garde_derive_tests/tests/snapshots/phone_number__phone_number_invalid.snap
+++ b/garde_derive_tests/tests/snapshots/phone_number__phone_number_invalid.snap
@@ -5,26 +5,26 @@ expression: snapshot
 Test {
     field: "14152370800",
 }
-`field` is not a valid phone number: invalid country code
+value.field: not a valid phone number: invalid country code
 
 Test {
     field: "0642926829",
 }
-`field` is not a valid phone number: invalid country code
+value.field: not a valid phone number: invalid country code
 
 Test {
     field: "00642926829",
 }
-`field` is not a valid phone number: invalid country code
+value.field: not a valid phone number: invalid country code
 
 Test {
     field: "A012",
 }
-`field` is not a valid phone number: invalid country code
+value.field: not a valid phone number: invalid country code
 
 Test {
     field: "TEXT",
 }
-`field` is not a valid phone number: not a number
+value.field: not a valid phone number: not a number
 
 

--- a/garde_derive_tests/tests/snapshots/prefix__prefix_invalid.snap
+++ b/garde_derive_tests/tests/snapshots/prefix__prefix_invalid.snap
@@ -5,11 +5,11 @@ expression: snapshot
 Test {
     field: "a",
 }
-`field` does not begin with "test"
+value.field: value does not begin with "test"
 
 Test {
     field: "_test",
 }
-`field` does not begin with "test"
+value.field: value does not begin with "test"
 
 

--- a/garde_derive_tests/tests/snapshots/range__range_invalid.snap
+++ b/garde_derive_tests/tests/snapshots/range__range_invalid.snap
@@ -5,11 +5,11 @@ expression: snapshot
 Test {
     field: 9,
 }
-`field` is out of bounds
+value.field: lower than 10
 
 Test {
     field: 101,
 }
-`field` is out of bounds
+value.field: greater than 100
 
 

--- a/garde_derive_tests/tests/snapshots/suffix__suffix_invalid.snap
+++ b/garde_derive_tests/tests/snapshots/suffix__suffix_invalid.snap
@@ -5,11 +5,11 @@ expression: snapshot
 Test {
     field: "a",
 }
-field does not end with "test"
+value.field: does not end with "test"
 
 Test {
     field: "test_",
 }
-field does not end with "test"
+value.field: does not end with "test"
 
 

--- a/garde_derive_tests/tests/snapshots/url__url_enum_invalid.snap
+++ b/garde_derive_tests/tests/snapshots/url__url_enum_invalid.snap
@@ -5,11 +5,11 @@ expression: snapshot
 Struct {
     field: "htt ps://www.youtube.com/watch?v=dQw4w9WgXcQ",
 }
-`field` is not a valid url: relative URL without a base
+value.field: not a valid url: relative URL without a base
 
 Tuple(
     "htt ps://www.youtube.com/watch?v=dQw4w9WgXcQ",
 )
-`test` is not a valid url: relative URL without a base
+value[0]: not a valid url: relative URL without a base
 
 

--- a/garde_derive_tests/tests/snapshots/url__url_invalid.snap
+++ b/garde_derive_tests/tests/snapshots/url__url_invalid.snap
@@ -5,6 +5,6 @@ expression: snapshot
 Struct {
     field: "asdf",
 }
-`field` is not a valid url: relative URL without a base
+value.field: not a valid url: relative URL without a base
 
 

--- a/garde_derive_tests/tests/snapshots/url__url_tuple_invalid.snap
+++ b/garde_derive_tests/tests/snapshots/url__url_tuple_invalid.snap
@@ -5,6 +5,6 @@ expression: snapshot
 Tuple(
     "htt ps://www.youtube.com/watch?v=dQw4w9WgXcQ",
 )
-`test` is not a valid url: relative URL without a base
+value[0]: not a valid url: relative URL without a base
 
 

--- a/garde_derive_tests/tests/url.rs
+++ b/garde_derive_tests/tests/url.rs
@@ -6,11 +6,12 @@ use garde::Validate;
 #[derive(Debug, Validate)]
 struct Struct<'a> {
     #[garde(url)]
+    #[garde(rename = "field")]
     field: &'a str,
 }
 
 #[derive(Debug, Validate)]
-struct Tuple<'a>(#[garde(rename = "test", url)] &'a str);
+struct Tuple<'a>(#[garde(url)] &'a str);
 
 #[derive(Debug, Validate)]
 enum Enum<'a> {
@@ -18,7 +19,7 @@ enum Enum<'a> {
         #[garde(url)]
         field: &'a str,
     },
-    Tuple(#[garde(rename = "test", url)] &'a str),
+    Tuple(#[garde(url)] &'a str),
 }
 
 #[test]

--- a/garde_derive_tests/tests/util/mod.rs
+++ b/garde_derive_tests/tests/util/mod.rs
@@ -29,7 +29,11 @@ pub fn __check_fail<T: Validate + Debug>(cases: &[T], ctx: &T::Context) -> Strin
     let mut snapshot = String::new();
     for case in cases {
         if let Err(error) = case.validate(ctx) {
-            writeln!(&mut snapshot, "{case:#?}\n{error}\n").unwrap();
+            writeln!(&mut snapshot, "{case:#?}").unwrap();
+            for (path, error) in error.flatten() {
+                writeln!(&mut snapshot, "{path}: {error}").unwrap();
+            }
+            writeln!(&mut snapshot).unwrap();
         } else {
             eprintln!(
                 "{} input: {case:?}",


### PR DESCRIPTION
Closes #6

The `Errors` type is now an enum with three variants:

- `Simple`, which is a list of individual `Error`s
- `List`, which is a list of nested `Errors`
- `Fields`, which is a map of `field -> Errors`

The type also exports builders for the three variants, which are used in the macro output for building up errors in a clean way. The `Errors` type may be flattened using `flatten`, which outputs a list of `(full_field_path, error)`.

A new `dive` rule was added which emits a call to `Validate::validate` instead of the usual calls to the individual rules. `dive` may not be combined with other rules (this is enforced by the macro).

### Example output

For the following structs:
```rust
#[derive(Validate)]
struct Inner<'a> {
    #[garde(length(min = 1))]
    field: &'a str,
}

#[derive(Validate)]
struct Test<'a> {
    #[garde(dive, length(min = 1))]
    field: Inner<'a>,
}
```

The proc macro will generate:
```rust
impl<'a> ::garde::Validate for Inner<'a> {
    type Context = ();
    fn validate(&self, ctx: &Self::Context) -> Result<(), ::garde::Errors> {
        let errors = ::garde::error::Errors::fields(|errors| {
            errors.insert(
                "field",
                ::garde::error::Errors::simple(|errors| {
                    if let Err(error) =
                        (::garde::rules::length::apply)(&self.field, (1usize, usize::MAX))
                    {
                        errors.push(error)
                    }
                }),
            );
        });
        if !errors.is_empty() {
            return Err(errors);
        }
        Ok(())
    }
}

impl<'a> ::garde::Validate for Test<'a> {
    type Context = ();
    fn validate(&self, ctx: &Self::Context) -> Result<(), ::garde::Errors> {
        let errors = ::garde::error::Errors::fields(|errors| {
            errors.insert(
                "field",
                ::garde::validate::Validate::validate(&self.field, ctx)
                    .err()
                    .unwrap_or_else(|| ::garde::error::Errors::empty()),
            );
        });
        if !errors.is_empty() {
            return Err(errors);
        }
        Ok(())
    }
}
```