### PR TITLE
Require some validation or skip

### DIFF
--- a/garde_derive_tests/tests/compile-fail/no_validation.rs
+++ b/garde_derive_tests/tests/compile-fail/no_validation.rs
@@ -1,6 +1,15 @@
 #[derive(garde::Validate)]
-struct Test<'a> {
-    field: &'a str,
+struct Struct {
+    field: u64,
+}
+
+#[derive(garde::Validate)]
+struct Tuple(u64);
+
+#[derive(garde::Validate)]
+enum Enum {
+    Struct { field: u64 },
+    Tuple(u64),
 }
 
 fn main() {}

--- a/garde_derive_tests/tests/compile-fail/no_validation.rs
+++ b/garde_derive_tests/tests/compile-fail/no_validation.rs
@@ -1,6 +1,5 @@
 #[derive(garde::Validate)]
 struct Test<'a> {
-    #[garde(ascii, unknown_rule)]
     field: &'a str,
 }
 

--- a/garde_derive_tests/tests/compile-fail/no_validation.stderr
+++ b/garde_derive_tests/tests/compile-fail/no_validation.stderr
@@ -1,0 +1,5 @@
+error: field has no validation, use `#[garde(skip)] if this is intentional
+ --> tests/compile-fail/no_validation.rs:3:5
+  |
+3 |     field: &'a str,
+  |     ^^^^^^^^^^^^^^

--- a/garde_derive_tests/tests/compile-fail/no_validation.stderr
+++ b/garde_derive_tests/tests/compile-fail/no_validation.stderr
@@ -1,5 +1,23 @@
-error: field has no validation, use `#[garde(skip)] if this is intentional
+error: field has no validation, use `#[garde(skip)]` if this is intentional
  --> tests/compile-fail/no_validation.rs:3:5
   |
-3 |     field: &'a str,
-  |     ^^^^^^^^^^^^^^
+3 |     field: u64,
+  |     ^^^^^^^^^^
+
+error: field has no validation, use `#[garde(skip)]` if this is intentional
+ --> tests/compile-fail/no_validation.rs:7:14
+  |
+7 | struct Tuple(u64);
+  |              ^^^
+
+error: field has no validation, use `#[garde(skip)]` if this is intentional
+  --> tests/compile-fail/no_validation.rs:11:14
+   |
+11 |     Struct { field: u64 },
+   |              ^^^^^^^^^^
+
+error: field has no validation, use `#[garde(skip)]` if this is intentional
+  --> tests/compile-fail/no_validation.rs:12:11
+   |
+12 |     Tuple(u64),
+   |           ^^^

--- a/garde_derive_tests/tests/compile-fail/unknown_rule.stderr
+++ b/garde_derive_tests/tests/compile-fail/unknown_rule.stderr
@@ -1,5 +1,5 @@
-error: unrecognized validation rule
- --> tests/compile-fail/unknown_rule.rs:3:13
+error: unrecognized rule
+ --> tests/compile-fail/unknown_rule.rs:3:20
   |
-3 |     #[garde(unknown_rule)]
-  |             ^^^^^^^^^^^^
+3 |     #[garde(ascii, unknown_rule)]
+  |                    ^^^^^^^^^^^^

--- a/garde_derive_tests/tests/compile-pass/skip.rs
+++ b/garde_derive_tests/tests/compile-pass/skip.rs
@@ -1,6 +1,6 @@
 #[derive(garde::Validate)]
 struct Test<'a> {
-    #[garde(ascii, unknown_rule)]
+    #[garde(skip)]
     field: &'a str,
 }
 

--- a/garde_derive_tests/tests/prefix.rs
+++ b/garde_derive_tests/tests/prefix.rs
@@ -16,3 +16,9 @@ fn prefix_valid() {
 fn prefix_invalid() {
     util::check_fail!(&[Test { field: "a" }, Test { field: "_test" }], &())
 }
+
+/* #[derive(garde::Validate)]
+struct Other<'a> {
+    #[garde(unknown_rule)]
+    field: &'a str,
+} */

--- a/garde_derive_tests/tests/prefix.rs
+++ b/garde_derive_tests/tests/prefix.rs
@@ -16,9 +16,3 @@ fn prefix_valid() {
 fn prefix_invalid() {
     util::check_fail!(&[Test { field: "a" }, Test { field: "_test" }], &())
 }
-
-/* #[derive(garde::Validate)]
-struct Other<'a> {
-    #[garde(unknown_rule)]
-    field: &'a str,
-} */

--- a/garde_derive_tests/tests/skip.rs
+++ b/garde_derive_tests/tests/skip.rs
@@ -1,0 +1,14 @@
+#[path = "./util/mod.rs"]
+mod util;
+
+#[allow(dead_code)]
+#[derive(Debug, garde::Validate)]
+struct Test {
+    #[garde(skip)]
+    field: u64,
+}
+
+#[test]
+fn skip_valid() {
+    util::check_ok(&[Test { field: 50 }], &())
+}

--- a/garde_derive_tests/tests/skip.rs
+++ b/garde_derive_tests/tests/skip.rs
@@ -3,12 +3,27 @@ mod util;
 
 #[allow(dead_code)]
 #[derive(Debug, garde::Validate)]
-struct Test {
+struct Struct {
     #[garde(skip)]
     field: u64,
 }
 
+#[allow(dead_code)]
+#[derive(Debug, garde::Validate)]
+struct Tuple(#[garde(skip)] u64);
+
+#[allow(dead_code)]
+#[derive(Debug, garde::Validate)]
+enum Enum {
+    Struct {
+        #[garde(skip)]
+        field: u64,
+    },
+    Tuple(#[garde(skip)] u64),
+}
+
 #[test]
 fn skip_valid() {
-    util::check_ok(&[Test { field: 50 }], &())
+    util::check_ok(&[Struct { field: 50 }], &());
+    util::check_ok(&[Tuple(50)], &());
 }

--- a/garde_derive_tests/tests/skip.rs
+++ b/garde_derive_tests/tests/skip.rs
@@ -26,4 +26,5 @@ enum Enum {
 fn skip_valid() {
     util::check_ok(&[Struct { field: 50 }], &());
     util::check_ok(&[Tuple(50)], &());
+    util::check_ok(&[Enum::Struct { field: 50 }, Enum::Tuple(50)], &());
 }


### PR DESCRIPTION
Closes #13 

Each field in a `derive(Validate)` type must now have at least one validation rule, or be marked `#[garde(dive)]`. `#[garde(skip)]` may be used to silence the error and opt out of validation altogether.