### PR TITLE
chore: Set `resolver = "2"` for workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "garde_derive", 
   "garde",
 ]
+resolver = "2"
 
 [workspace.dependencies]
 # Workspace crates


### PR DESCRIPTION
Using  `edition = "2021"` in a package will imply `resolver = "2"` unless you use a  [virtual workspace](https://doc.rust-lang.org/nightly/cargo/reference/workspaces.html#virtual-manifest) . When using a virtual workspace, [you must explicitly set `resolver = "2"` in its `Cargo.toml`](https://doc.rust-lang.org/nightly/edition-guide/rust-2021/default-cargo-resolver.html#details). This PR adds `resolver = "2"` to the workspace `Cargo.toml` to enable its usage everywhere in the workspace.