### PR TITLE
chore: upgrade axum-test to latest

### DIFF
--- a/integrations/axum_garde/Cargo.toml
+++ b/integrations/axum_garde/Cargo.toml
@@ -33,7 +33,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1.0.96" }
 garde = { version = "0.11.2", path = "../../garde", features = ["default", "derive"] }
 axum = { version = "0.6.17", features = ["default", "macros"] }
-axum-test = { version = "7.3.0" }
+axum-test = { version = "10.1.0" }
 tokio = { version = "1.28.0", features = ["full"] }
 prost = { version = "0.11.9" }
 rstest = { version = "0.17.0" }

--- a/integrations/axum_garde/tests/e2e.rs
+++ b/integrations/axum_garde/tests/e2e.rs
@@ -64,10 +64,8 @@ async fn assert_that_valid_requests_are_transparent(
 
     assert_that!(obtained.headers()).is_equal_to(expected.headers());
 
-    obtained
-        .assert_status(expected.status_code());
-    obtained
-        .assert_json(&expected.json::<Person>());
+    obtained.assert_status(expected.status_code());
+    obtained.assert_json(&expected.json::<Person>());
 }
 
 #[rstest]

--- a/integrations/axum_garde/tests/e2e.rs
+++ b/integrations/axum_garde/tests/e2e.rs
@@ -65,7 +65,8 @@ async fn assert_that_valid_requests_are_transparent(
     assert_that!(obtained.headers()).is_equal_to(expected.headers());
 
     obtained
-        .assert_status(expected.status_code())
+        .assert_status(expected.status_code());
+    obtained
         .assert_json(&expected.json::<Person>());
 }
 


### PR DESCRIPTION
This is a small and very minor PR to upgrade the version of axum-test in use.

## Changes

 * Upgrade axum-test to latest.
 * Fix breaking changes for tests.

## Testing

 * I've ran all tests locally with `cargo test --all-workspaces`

## Comments

I saw you were using this library and just fancied making the change for you.
