### PR TITLE
Disable unnecessary/unused regex features

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Additional notes:
 - `length` and `range` use an *inclusive* upper bound (`min..=max`).
 - `length` uses `.chars().count()` for UTF-8 strings instead of `.len()`.
 - For `contains`, `prefix`, and `suffix`, the pattern must be a string literal, because the `Pattern` API [is currently unstable](https://github.com/rust-lang/rust/issues/27721).
+- Garde does not enable the default features of the `regex` crate - if you need extra regex features (e.g. Unicode) or better performance, add a dependency on `regex = "1"` to your `Cargo.toml`.
 
 If most of the fields on your struct are annotated with `#[garde(skip)]`, you may use `#[garde(allow_unvalidated)]` instead:
 

--- a/garde/Cargo.toml
+++ b/garde/Cargo.toml
@@ -37,7 +37,7 @@ serde = { version = "1", features = ["derive"], optional = true }
 url = { version = "2", optional = true }
 card-validate = { version = "2.3", optional = true }
 phonenumber = { version = "0.3.2+8.13.9", optional = true }
-regex = { version = "1", optional = true }
+regex = { version = "1", default-features = false, features = ["std"], optional = true }
 once_cell = { version = "1", optional = true }
 idna = { version = "0.3", optional = true }
 

--- a/garde/src/lib.rs
+++ b/garde/src/lib.rs
@@ -94,6 +94,7 @@
 //! - `length` and `range` use an *inclusive* upper bound (`min..=max`).
 //! - `length` uses `.chars().count()` for UTF-8 strings instead of `.len()`.
 //! - For `contains`, `prefix`, and `suffix`, the pattern must be a string literal, because the `Pattern` API [is currently unstable](https://github.com/rust-lang/rust/issues/27721).
+//! - Garde does not enable the default features of the `regex` crate - if you need extra regex features (e.g. Unicode) or better performance, add a dependency on `regex = "1"` to your `Cargo.toml`.
 //!
 //! If most of the fields on your struct are annotated with `#[garde(skip)]`, you may use `#[garde(allow_unvalidated)]` instead:
 //!

--- a/garde/src/rules/email.rs
+++ b/garde/src/rules/email.rs
@@ -91,7 +91,7 @@ pub fn parse_email(s: &str) -> Result<(), InvalidEmail> {
         return Err(InvalidEmail::UserLengthExceeded);
     }
     static USER_RE: Lazy<Regex> =
-        Lazy::new(|| Regex::new(r"(?i)^[a-z0-9.!#$%&'*+/=?^_`{|}~-]+\z").unwrap());
+        Lazy::new(|| Regex::new(r"(?i-u)^[a-z0-9.!#$%&'*+/=?^_`{|}~-]+\z").unwrap());
     if !USER_RE.is_match(user) {
         return Err(InvalidEmail::InvalidUser);
     }
@@ -124,7 +124,7 @@ pub fn parse_email(s: &str) -> Result<(), InvalidEmail> {
 
 fn is_valid_domain(domain: &str) -> bool {
     static DOMAIN_NAME_RE: Lazy<Regex> = Lazy::new(|| {
-        Regex::new(r"(?i)^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*$").unwrap()
+        Regex::new(r"(?i-u)^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*$").unwrap()
     });
 
     if DOMAIN_NAME_RE.is_match(domain) {

--- a/garde_derive/Cargo.toml
+++ b/garde_derive/Cargo.toml
@@ -19,4 +19,4 @@ default = ["regex"]
 syn = { version = "2", features = ["full"] }
 quote = { version = "1" }
 proc-macro2 = { version = "1" }
-regex = { version = "1", optional = true }
+regex = { version = "1", default-features = false, features = ["std"], optional = true }


### PR DESCRIPTION
regex crate with default features enabled is huge, it significantly increases the binary size and compile time.

Cargo features are additive, so once some feature is enabled anywhere in the dependency graph, there's no way to disable it, i.e. one (transitive) dependency infects the whole dependency graph.