### PR TITLE
Added support for WASI/WASIX

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,9 @@ resolver = "2"
 [profile.dev.package]
 insta = { opt-level = 3 }
 trybuild = { opt-level = 3 }
+
+[patch.crates-io]
+tokio = { git = "https://github.com/wasix-org/tokio.git", branch = "epoll" }
+socket2 = { git = "https://github.com/wasix-org/socket2.git", branch = "v0.4.9" }
+libc = { git = "https://github.com/wasix-org/libc.git", branch = "master" }
+hyper = {  git = "https://github.com/wasix-org/hyper.git", branch = "v0.14.27" }

--- a/integrations/axum_garde/Cargo.toml
+++ b/integrations/axum_garde/Cargo.toml
@@ -21,8 +21,9 @@ axum-extra-protobuf = ["axum-extra/protobuf"]
 axum-extra-query = ["axum-extra/query"]
 
 [dependencies]
-axum = { version = "0.6.17", default-features = false }
-axum-extra = { version = "0.7.4", default-features = false, optional = true }
+axum = { version = "=0.6.9", default-features = false }
+hyper = { version = "=0.14.27", default-features = false }
+axum-extra = { version = "0.7", default-features = false, optional = true }
 axum-yaml = { version = "0.3.0", default-features = false, optional = true }
 axum-msgpack = { version = "0.3.0", default-features = false, optional = true }
 garde = { version = "0.14.0", path = "../../garde", default-features = false }
@@ -32,9 +33,9 @@ thiserror = { version = "1.0.40", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1.0.96" }
 garde = { version = "0.14.0", path = "../../garde", features = ["default", "derive"] }
-axum = { version = "0.6.17", features = ["default", "macros"] }
-axum-test = { version = "10.1.0" }
-tokio = { version = "1.28.0", features = ["full"] }
+axum = { version = "=0.6.9", features = ["default", "macros"] }
+axum-test = { version = "*" }
+tokio = { version = "=1.24.2", features = ["full"] }
 prost = { version = "0.11.9" }
 rstest = { version = "0.17.0" }
 speculoos = { version = "0.11.0" }

--- a/integrations/axum_garde/WASIX.md
+++ b/integrations/axum_garde/WASIX.md
@@ -1,0 +1,30 @@
+Garde now fully supports running in WebAssembly using axum on the browser or from the Edge.
+
+Just compile with this...
+
+```
+cargo wasix build --examples
+```
+
+You can then run it with this...
+```
+wasmer run --net target/wasm32-wasmer-wasi/debug/examples/json.wasm
+```
+
+Try some examples, like this:
+
+```
+user@laptop:/prog/garde$ echo "{ \"username\": \"bob\", \"password\": \"toosmall\" }" | curl --data-binary @- -H "Content-Type: application/json" http://127.0.0.1:8080/person
+value.password: length is lower than 15
+```
+
+```
+user@laptop:/prog/garde$ echo "{ \"username\": \"bob\", \"password\": \"asjdnfkjasndfkjansdf\" }" | curl --data-binary @- -H "Content-Type: application/json" http://127.0.0.1:8080/person
+{"username":"bob","password":"asjdnfkjasndfkjansdf"}
+```
+
+You can also test it on Wasmer Edge like this:
+
+```
+user@laptop:/prog/garde$ echo "{ \"username\": \"bob\", \"password\": \"asjdnfkjasndfkjansdf\" }" | curl --data-binary @- -H "Content-Type: application/json" https://garde.wasmer.app/person
+```


### PR DESCRIPTION
Garde now fully supports running in WebAssembly using axum on the browser or from the Edge.

Just compile with this...

```
cargo wasix build --examples
```

You can then run it with this...
```
wasmer run --net target/wasm32-wasmer-wasi/debug/examples/json.wasm
```

Try some examples, like this:

```
echo "{ \"username\": \"bob\", \"password\": \"toosmall\" }" | curl --data-binary @- -H "Content-Type: application/json" http://127.0.0.1:8080/person
value.password: length is lower than 15
```

```
echo "{ \"username\": \"bob\", \"password\": \"asjdnfkjasndfkjansdf\" }" | curl --data-binary @- -H "Content-Type: application/json" http://127.0.0.1:8080/person
{"username":"bob","password":"asjdnfkjasndfkjansdf"}
```

You can also test it on Wasmer Edge like this:

```
echo "{ \"username\": \"bob\", \"password\": \"asjdnfkjasndfkjansdf\" }" | curl --data-binary @- -H "Content-Type: application/json" https://garde.wasmer.app/person
```