### PR TITLE
feat: inner option support

### DIFF
--- a/garde/README.md
+++ b/garde/README.md
@@ -12,7 +12,7 @@ A Rust validation library
 - [Inner type validation](#inner-type-validation)
 - [Handling Option](#handling-option)
 - [Custom validation](#custom-validation)
-- [Custom validation with containers](#custom-validation)
+- [Custom validation with containers](#custom-validation-with-containers)
 - [Context/Self access](#contextself-access)
 - [Implementing rules](#implementing-rules)
 - [Implementing `Validate`](#implementing-validate)

--- a/garde/src/error.rs
+++ b/garde/src/error.rs
@@ -92,8 +92,19 @@ pub struct Path {
 #[doc(hidden)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Kind {
+    None,
     Key,
     Index,
+}
+
+#[doc(hidden)]
+#[derive(Default)]
+pub struct NoKey(());
+
+impl std::fmt::Display for NoKey {
+    fn fmt(&self, _: &mut std::fmt::Formatter) -> std::fmt::Result {
+        Ok(())
+    }
 }
 
 pub trait PathComponentKind: std::fmt::Display + ToCompactString + private::Sealed {
@@ -116,6 +127,7 @@ impl_path_component_kind!(@'a; &'a str => Key);
 impl_path_component_kind!(@'a; Cow<'a, str> => Key);
 impl_path_component_kind!(String => Key);
 impl_path_component_kind!(CompactString => Key);
+impl_path_component_kind!(NoKey => None);
 
 impl<'a, T: PathComponentKind> private::Sealed for &'a T {}
 impl<'a, T: PathComponentKind> PathComponentKind for &'a T {
@@ -204,6 +216,7 @@ impl std::fmt::Display for Path {
             }
             if let Some((kind, _)) = components.peek() {
                 match kind {
+                    Kind::None => {}
                     Kind::Key => f.write_str(".")?,
                     Kind::Index => f.write_str("[")?,
                 }

--- a/garde/tests/rules/inner.rs
+++ b/garde/tests/rules/inner.rs
@@ -26,3 +26,96 @@ fn alphanumeric_invalid() {
         &()
     )
 }
+
+#[derive(Debug, garde::Validate)]
+struct NotNestedOption<'a> {
+    #[garde(inner(alphanumeric))]
+    inner: Option<&'a str>,
+}
+
+#[derive(Debug, garde::Validate)]
+struct NestedSliceInsideOption<'a> {
+    #[garde(inner(inner(alphanumeric)))]
+    inner: Option<&'a [&'a str]>,
+}
+
+#[derive(Debug, garde::Validate)]
+struct DoubleNestedSliceInsideOption<'a> {
+    #[garde(inner(inner(inner(alphanumeric))))]
+    inner: Option<&'a [&'a [&'a str]]>,
+}
+
+#[derive(Debug, garde::Validate)]
+struct OptionInsideSlice<'a> {
+    #[garde(inner(inner(alphanumeric)))]
+    inner: &'a [Option<&'a str>],
+}
+
+#[test]
+fn alphanumeric_some_valid() {
+    util::check_ok(
+        &[NotNestedOption {
+            inner: Some("abcd0123"),
+        }],
+        &(),
+    );
+    util::check_ok(
+        &[NestedSliceInsideOption {
+            inner: Some(&["abcd0123"]),
+        }],
+        &(),
+    );
+    util::check_ok(
+        &[DoubleNestedSliceInsideOption {
+            inner: Some(&[&["abcd0123"]]),
+        }],
+        &(),
+    );
+    util::check_ok(
+        &[OptionInsideSlice {
+            inner: &[Some("abcd0123")],
+        }],
+        &(),
+    )
+}
+
+#[test]
+fn alphanumeric_some_invalid() {
+    util::check_fail!(
+        &[NotNestedOption {
+            inner: Some("!!!!"),
+        }],
+        &(),
+    );
+    util::check_fail!(
+        &[NestedSliceInsideOption {
+            inner: Some(&["!!!!"]),
+        }],
+        &(),
+    );
+    util::check_fail!(
+        &[DoubleNestedSliceInsideOption {
+            inner: Some(&[&["!!!!"]]),
+        }],
+        &(),
+    );
+    util::check_fail!(
+        &[OptionInsideSlice {
+            inner: &[Some("!!!!")],
+        }],
+        &(),
+    )
+}
+
+#[test]
+fn alphanumeric_none_valid() {
+    util::check_ok(&[NotNestedOption { inner: None }], &());
+    util::check_ok(&[NestedSliceInsideOption { inner: None }], &());
+    util::check_ok(&[DoubleNestedSliceInsideOption { inner: None }], &());
+    util::check_ok(
+        &[OptionInsideSlice {
+            inner: &[None, None],
+        }],
+        &(),
+    )
+}

--- a/garde/tests/rules/snapshots/rules__rules__inner__alphanumeric_some_invalid-2.snap
+++ b/garde/tests/rules/snapshots/rules__rules__inner__alphanumeric_some_invalid-2.snap
@@ -1,0 +1,15 @@
+---
+source: garde/tests/./rules/inner.rs
+assertion_line: 90
+expression: snapshot
+---
+NestedSliceInsideOption {
+    inner: Some(
+        [
+            "!!!!",
+        ],
+    ),
+}
+inner[0]: not alphanumeric
+
+

--- a/garde/tests/rules/snapshots/rules__rules__inner__alphanumeric_some_invalid-3.snap
+++ b/garde/tests/rules/snapshots/rules__rules__inner__alphanumeric_some_invalid-3.snap
@@ -1,0 +1,17 @@
+---
+source: garde/tests/./rules/inner.rs
+assertion_line: 96
+expression: snapshot
+---
+DoubleNestedSliceInsideOption {
+    inner: Some(
+        [
+            [
+                "!!!!",
+            ],
+        ],
+    ),
+}
+inner[0][0]: not alphanumeric
+
+

--- a/garde/tests/rules/snapshots/rules__rules__inner__alphanumeric_some_invalid-4.snap
+++ b/garde/tests/rules/snapshots/rules__rules__inner__alphanumeric_some_invalid-4.snap
@@ -1,0 +1,15 @@
+---
+source: garde/tests/./rules/inner.rs
+assertion_line: 102
+expression: snapshot
+---
+OptionInsideSlice {
+    inner: [
+        Some(
+            "!!!!",
+        ),
+    ],
+}
+inner[0]: not alphanumeric
+
+

--- a/garde/tests/rules/snapshots/rules__rules__inner__alphanumeric_some_invalid.snap
+++ b/garde/tests/rules/snapshots/rules__rules__inner__alphanumeric_some_invalid.snap
@@ -1,0 +1,13 @@
+---
+source: garde/tests/./rules/inner.rs
+assertion_line: 84
+expression: snapshot
+---
+NotNestedOption {
+    inner: Some(
+        "!!!!",
+    ),
+}
+inner: not alphanumeric
+
+


### PR DESCRIPTION
When working with custom validators, if the type is a container such as `Vec<T>` or `Option<T>`, the validation function will get a reference to that container instead of the underlying data. This is in contrast with built-in validators that are able to extract the type from some container types such as `Option<T>`.

This PR builds on top of the existing implementations for slice-like containers by adding support for `Option<T>` to the `inner` modifier.

This allows you to easily use the same validation function for `T` as you do for `Option<T>` or `Vec<T>`.