### PR TITLE
Newtype

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,11 +64,11 @@ jobs:
             rust: 1.69
             # Fails on pinned version because the output changed,
             # so we're excluding it, but it's still tested on stable and nightly.
-            EXCLUDE_UI_TESTS: "pattern_mismatched_types"
+            EXCLUDE_UI_TESTS: "pattern_mismatched_types,newtype"
           - build: stable
             os: ubuntu-20.04
             rust: stable
-            EXCLUDE_UI_TESTS: ""
+            EXCLUDE_UI_TESTS: "newtype"
           - build: nightly
             os: ubuntu-20.04
             rust: nightly

--- a/garde/tests/rules/ascii.rs
+++ b/garde/tests/rules/ascii.rs
@@ -1,4 +1,5 @@
 use super::util;
+
 #[derive(Debug, garde::Validate)]
 struct Test<'a> {
     #[garde(ascii)]

--- a/garde/tests/rules/credit_card.rs
+++ b/garde/tests/rules/credit_card.rs
@@ -1,4 +1,5 @@
 use super::util;
+
 #[derive(Debug, garde::Validate)]
 struct Test<'a> {
     #[garde(credit_card)]

--- a/garde/tests/rules/custom.rs
+++ b/garde/tests/rules/custom.rs
@@ -1,4 +1,5 @@
 use super::util;
+
 struct Context {
     needle: String,
 }

--- a/garde/tests/rules/email.rs
+++ b/garde/tests/rules/email.rs
@@ -1,4 +1,5 @@
 use super::util;
+
 #[derive(Debug, garde::Validate)]
 struct Test<'a> {
     #[garde(email)]

--- a/garde/tests/rules/ip.rs
+++ b/garde/tests/rules/ip.rs
@@ -1,4 +1,5 @@
 use super::util;
+
 #[derive(Debug, garde::Validate)]
 struct TestIpAny<'a> {
     #[garde(ip)]

--- a/garde/tests/rules/mod.rs
+++ b/garde/tests/rules/mod.rs
@@ -12,6 +12,7 @@ mod inner;
 mod ip;
 mod length;
 mod multi_rule;
+mod newtype;
 mod option;
 mod pattern;
 mod phone_number;

--- a/garde/tests/rules/multi_rule.rs
+++ b/garde/tests/rules/multi_rule.rs
@@ -1,4 +1,5 @@
 use super::util;
+
 #[derive(Debug, garde::Validate)]
 struct Test<'a> {
     #[garde(prefix("test"), ascii, length(min = 10, max = 100))]

--- a/garde/tests/rules/newtype.rs
+++ b/garde/tests/rules/newtype.rs
@@ -1,0 +1,45 @@
+#![allow(non_camel_case_types)]
+
+use super::util;
+
+#[derive(Debug, garde::Validate)]
+#[garde(transparent)]
+struct NonEmptyStr_Struct<'a> {
+    #[garde(length(min = 1))]
+    v: &'a str,
+}
+
+#[derive(Debug, garde::Validate)]
+#[garde(transparent)]
+struct NonEmptyStr_Tuple<'a>(#[garde(length(min = 1))] &'a str);
+
+#[derive(Debug, garde::Validate)]
+
+struct Test<'a> {
+    #[garde(dive)]
+    a: NonEmptyStr_Struct<'a>,
+    #[garde(dive)]
+    b: NonEmptyStr_Tuple<'a>,
+}
+
+#[test]
+fn newtype_valid() {
+    util::check_ok(
+        &[Test {
+            a: NonEmptyStr_Struct { v: "test" },
+            b: NonEmptyStr_Tuple("test"),
+        }],
+        &(),
+    );
+}
+
+#[test]
+fn newtype_invalid() {
+    util::check_fail!(
+        &[Test {
+            a: NonEmptyStr_Struct { v: "" },
+            b: NonEmptyStr_Tuple(""),
+        }],
+        &()
+    );
+}

--- a/garde/tests/rules/phone_number.rs
+++ b/garde/tests/rules/phone_number.rs
@@ -1,4 +1,5 @@
 use super::util;
+
 #[derive(Debug, garde::Validate)]
 struct Test<'a> {
     #[garde(phone_number)]

--- a/garde/tests/rules/range.rs
+++ b/garde/tests/rules/range.rs
@@ -1,4 +1,5 @@
 use super::util;
+
 #[derive(Debug, garde::Validate)]
 struct Test<'a> {
     #[garde(range(min = 10, max = 100))]

--- a/garde/tests/rules/skip.rs
+++ b/garde/tests/rules/skip.rs
@@ -1,4 +1,5 @@
 use super::util;
+
 #[allow(dead_code)]
 #[derive(Debug, garde::Validate)]
 struct Struct {

--- a/garde/tests/rules/snapshots/rules__rules__newtype__newtype_invalid.snap
+++ b/garde/tests/rules/snapshots/rules__rules__newtype__newtype_invalid.snap
@@ -1,0 +1,16 @@
+---
+source: garde/tests/./rules/newtype.rs
+expression: snapshot
+---
+Test {
+    a: NonEmptyStr_Struct {
+        v: "",
+    },
+    b: NonEmptyStr_Tuple(
+        "",
+    ),
+}
+a: length is lower than 1
+b: length is lower than 1
+
+

--- a/garde/tests/ui/compile-fail/non_unary_newtype.rs
+++ b/garde/tests/ui/compile-fail/non_unary_newtype.rs
@@ -1,0 +1,24 @@
+#![allow(dead_code)]
+
+#[derive(Debug, garde::Validate)]
+#[garde(transparent)]
+struct EmptyTuple();
+
+#[derive(Debug, garde::Validate)]
+#[garde(transparent)]
+struct EmptyStruct {}
+
+#[derive(Debug, garde::Validate)]
+#[garde(transparent)]
+struct NonUnaryTuple<'a>(#[garde(ascii)] &'a str, #[garde(ascii)] &'a str);
+
+#[derive(Debug, garde::Validate)]
+#[garde(transparent)]
+struct NonUnaryStruct<'a> {
+    #[garde(ascii)]
+    a: &'a str,
+    #[garde(ascii)]
+    b: &'a str,
+}
+
+fn main() {}

--- a/garde/tests/ui/compile-fail/non_unary_newtype.stderr
+++ b/garde/tests/ui/compile-fail/non_unary_newtype.stderr
@@ -1,0 +1,23 @@
+error: transparent structs must have exactly one field
+ --> tests/ui/compile-fail/non_unary_newtype.rs
+  |
+  | #[garde(transparent)]
+  | ^^^^^^^^^^^^^^^^^^^^^
+
+error: transparent structs must have exactly one field
+ --> tests/ui/compile-fail/non_unary_newtype.rs
+  |
+  | #[garde(transparent)]
+  | ^^^^^^^^^^^^^^^^^^^^^
+
+error: transparent structs must have exactly one field
+ --> tests/ui/compile-fail/non_unary_newtype.rs
+  |
+  | #[garde(transparent)]
+  | ^^^^^^^^^^^^^^^^^^^^^
+
+error: transparent structs must have exactly one field
+ --> tests/ui/compile-fail/non_unary_newtype.rs
+  |
+  | #[garde(transparent)]
+  | ^^^^^^^^^^^^^^^^^^^^^

--- a/garde/tests/ui/compile-pass/newtype.rs
+++ b/garde/tests/ui/compile-pass/newtype.rs
@@ -1,0 +1,27 @@
+#![allow(dead_code)]
+
+#[derive(Debug, garde::Validate)]
+#[garde(transparent)]
+struct UnaryTuple<'a>(#[garde(ascii)] &'a str);
+
+#[derive(Debug, garde::Validate)]
+#[garde(transparent)]
+struct UnaryStruct<'a> {
+    #[garde(ascii)]
+    a: &'a str,
+}
+
+#[derive(Debug, garde::Validate)]
+#[garde(transparent)]
+struct TupleWithSkippedField<'a>(#[garde(ascii)] &'a str, #[garde(skip)] &'a str);
+
+#[derive(Debug, garde::Validate)]
+#[garde(transparent)]
+struct StructWithSkippedField<'a> {
+    #[garde(ascii)]
+    a: &'a str,
+    #[garde(skip)]
+    b: &'a str,
+}
+
+fn main() {}

--- a/garde_derive/src/model.rs
+++ b/garde_derive/src/model.rs
@@ -14,6 +14,7 @@ pub struct Input {
 pub enum Attr {
     Context(Box<Type>, Ident),
     AllowUnvalidated,
+    Transparent,
 }
 
 impl Attr {
@@ -29,6 +30,7 @@ impl Attr {
         match self {
             Attr::Context(..) => "context",
             Attr::AllowUnvalidated => "allow_unvalidated",
+            Attr::Transparent => "transparent",
         }
     }
 }
@@ -140,6 +142,7 @@ pub struct Validate {
     pub ident: Ident,
     pub generics: Generics,
     pub context: (Type, Ident),
+    pub is_transparent: bool,
     pub kind: ValidateKind,
     pub options: Options,
 }

--- a/garde_derive/src/syntax.rs
+++ b/garde_derive/src/syntax.rs
@@ -100,6 +100,7 @@ impl Parse for model::Attr {
                 Ok(model::Attr::Context(Box::new(ty), ident))
             }
             "allow_unvalidated" => Ok(model::Attr::AllowUnvalidated),
+            "transparent" => Ok(model::Attr::Transparent),
             _ => Err(syn::Error::new(ident.span(), "unrecognized attribute")),
         }
     }


### PR DESCRIPTION
Closes https://github.com/jprochazk/garde/issues/50

Adds the `#[garde(transparent)]` attribute, which may be used to create easily re-usable newtypes:

```rust
#[derive(garde::Validate)]
#[garde(transparent)]
struct Username(#[garde(length(min = 3, max = 20))] String);

#[derive(garde::Validate)]
struct User {
    #[garde(dive)]
    username: Username,
}
```

`#[garde(transparent)]` is only allowed on tuples and structs with exactly one field. It will flatten the error path by one level, which means that `User.username[0]` will be just `User.username` instead, resulting in nicer error messages:

```
User {
  username: Username("")
}

username: length is lower than 3
```