### PR TITLE
Update axum to 0.7

### DIFF
--- a/integrations/axum_garde/Cargo.toml
+++ b/integrations/axum_garde/Cargo.toml
@@ -23,8 +23,8 @@ axum-extra-query = ["axum-extra/query"]
 [dependencies]
 axum = { version = "0.7", default-features = false }
 axum-extra = { version = "0.9", default-features = false, optional = true }
-axum-yaml = { version = "0.3", default-features = false, optional = true }
-axum-msgpack = { version = "0.3", default-features = false, optional = true }
+axum-yaml = { version = "0.4", default-features = false, optional = true }
+axum-msgpack = { version = "0.4", default-features = false, optional = true }
 garde = { path = "../../garde", default-features = false }
 thiserror = { version = "1.0", default-features = false }
 

--- a/integrations/axum_garde/Cargo.toml
+++ b/integrations/axum_garde/Cargo.toml
@@ -21,23 +21,23 @@ axum-extra-protobuf = ["axum-extra/protobuf"]
 axum-extra-query = ["axum-extra/query"]
 
 [dependencies]
-axum = { version = "0.6.17", default-features = false }
-axum-extra = { version = "0.7.4", default-features = false, optional = true }
-axum-yaml = { version = "0.3.0", default-features = false, optional = true }
-axum-msgpack = { version = "0.3.0", default-features = false, optional = true }
-garde = { version = "0.16.0", path = "../../garde", default-features = false }
-thiserror = { version = "1.0.40", default-features = false }
+axum = { version = "0.7", default-features = false }
+axum-extra = { version = "0.9", default-features = false, optional = true }
+axum-yaml = { version = "0.3", default-features = false, optional = true }
+axum-msgpack = { version = "0.3", default-features = false, optional = true }
+garde = { path = "../../garde", default-features = false }
+thiserror = { version = "1.0", default-features = false }
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }
-serde_json = { version = "1.0.96" }
-garde = { version = "0.16.0", path = "../../garde", features = ["default", "derive"] }
-axum = { version = "0.6.17", features = ["default", "macros"] }
-axum-test = { version = "10.1.0" }
-tokio = { version = "1.28.0", features = ["full"] }
-prost = { version = "0.11.9" }
-rstest = { version = "0.17.0" }
-speculoos = { version = "0.11.0" }
+serde_json = { version = "1" }
+garde = { version = "0.16", path = "../../garde", features = ["default", "derive"] }
+axum = { version = "0.7", features = ["default", "macros"] }
+axum-test = { version = "14.1" }
+tokio = { version = "1.28", features = ["full"] }
+prost = { version = "0.12" }
+rstest = { version = "0.18" }
+speculoos = { version = "0.11" }
 
 [[example]]
 name = "json"

--- a/integrations/axum_garde/examples/custom_validation.rs
+++ b/integrations/axum_garde/examples/custom_validation.rs
@@ -58,7 +58,6 @@ async fn main() {
         TcpListener::bind("127.0.0.1:8080")
             .await
             .expect("Failed to bind the address"),
-            
         app.into_make_service(),
     )
     .await

--- a/integrations/axum_garde/examples/custom_validation.rs
+++ b/integrations/axum_garde/examples/custom_validation.rs
@@ -7,10 +7,11 @@
 //! ```
 use axum::response::IntoResponse;
 use axum::routing::post;
-use axum::{Json, Router, Server};
+use axum::{Json, Router};
 use axum_garde::WithValidation;
 use garde::Validate;
 use serde::{Deserialize, Serialize};
+use tokio::net::TcpListener;
 
 // Define your valid scheme
 #[derive(Debug, Serialize, Deserialize, Validate)]
@@ -50,9 +51,16 @@ async fn main() {
         .route("/person", post(insert_valid_person))
         // Create the application state
         .with_state(PasswordContext { complexity: 10 });
+
     println!("See example: http://127.0.0.1:8080/person");
-    Server::bind(&([127, 0, 0, 1], 8080).into())
-        .serve(app.into_make_service())
-        .await
-        .unwrap();
+
+    axum::serve(
+        TcpListener::bind("127.0.0.1:8080")
+            .await
+            .expect("Failed to bind the address"),
+            
+        app.into_make_service(),
+    )
+    .await
+    .expect("Failed to start axum serve");
 }

--- a/integrations/axum_garde/examples/json.rs
+++ b/integrations/axum_garde/examples/json.rs
@@ -7,10 +7,11 @@
 //! ```
 use axum::response::IntoResponse;
 use axum::routing::post;
-use axum::{Json, Router, Server};
+use axum::{Json, Router};
 use axum_garde::WithValidation;
 use garde::Validate;
 use serde::{Deserialize, Serialize};
+use tokio::net::TcpListener;
 
 // Define your valid scheme
 #[derive(Debug, Serialize, Deserialize, Validate)]
@@ -43,9 +44,16 @@ async fn main() {
         .route("/person", post(insert_valid_person))
         // Create the application state
         .with_state(AppState);
+    
     println!("See example: http://127.0.0.1:8080/person");
-    Server::bind(&([127, 0, 0, 1], 8080).into())
-        .serve(app.into_make_service())
-        .await
-        .unwrap();
+    
+    axum::serve(
+        TcpListener::bind("127.0.0.1:8080")
+            .await
+            .expect("Failed to bind the address"),
+            
+        app.into_make_service(),
+    )
+    .await
+    .expect("Failed to start axum serve");
 }

--- a/integrations/axum_garde/examples/json.rs
+++ b/integrations/axum_garde/examples/json.rs
@@ -44,14 +44,13 @@ async fn main() {
         .route("/person", post(insert_valid_person))
         // Create the application state
         .with_state(AppState);
-    
+
     println!("See example: http://127.0.0.1:8080/person");
-    
+
     axum::serve(
         TcpListener::bind("127.0.0.1:8080")
             .await
             .expect("Failed to bind the address"),
-            
         app.into_make_service(),
     )
     .await

--- a/integrations/axum_garde/src/error.rs
+++ b/integrations/axum_garde/src/error.rs
@@ -11,6 +11,7 @@ pub enum WithValidationRejection<T> {
     /// Variant for the extractor's rejection
     #[error(transparent)]
     ExtractionError(T),
+
     /// Variant for the payload's validation errors. Responds with status code
     /// `422 Unprocessable Content`
     #[error(transparent)]

--- a/integrations/axum_garde/src/into_inner.rs
+++ b/integrations/axum_garde/src/into_inner.rs
@@ -22,7 +22,8 @@ macro_rules! impl_into_inner_simple {
         }
     };
 }
-#[allow(unused_macros)]
+
+#[cfg(feature = "axum-extra")]
 macro_rules! impl_into_inner_wrapper {
     (
         $name:ty,

--- a/integrations/axum_garde/src/with_validation.rs
+++ b/integrations/axum_garde/src/with_validation.rs
@@ -30,19 +30,19 @@ use super::{IntoInner, WithValidationRejection};
 /// use serde::{Serialize,Deserialize};
 /// use garde::Validate;
 /// use axum_garde::WithValidation;
-/// 
+///
 /// #[derive(Debug, Serialize, Deserialize, Validate)]
 /// struct Person {
 ///     #[garde(length(min = 1, max = 10))]
 ///     name: String
 /// }
-/// 
+///
 /// async fn handler(
 ///     WithValidation(valid_person): WithValidation<Json<Person>>,
 /// ) -> String{
 ///     format!("{valid_person:?}")
 /// }
-/// 
+///
 /// # // Assert that handler compiles
 /// # axum::Router::new()
 /// #   .route("/", axum::routing::post(handler))

--- a/integrations/axum_garde/src/with_validation.rs
+++ b/integrations/axum_garde/src/with_validation.rs
@@ -2,6 +2,7 @@ use std::fmt::Debug;
 use std::ops::Deref;
 
 use axum::async_trait;
+use axum::body::Body;
 use axum::extract::{FromRef, FromRequest, FromRequestParts};
 use axum::http::request::Parts;
 use axum::http::Request;
@@ -22,34 +23,32 @@ use super::{IntoInner, WithValidationRejection};
 /// The desired validation context ([`garde::Validate::Context`](garde::Validate))
 /// must be provided as router state
 ///
-#[cfg_attr(
-    feature = "json",
-    doc = r#"
-### Example
-
-```
-use axum::Json;
-use serde::{Serialize,Deserialize};
-use garde::Validate;
-use axum_garde::WithValidation;
-#[derive(Debug, Serialize, Deserialize, Validate)]
-struct Person {
-    #[garde(length(min = 1, max = 10))]
-    name: String
-}
-async fn handler(
-    WithValidation(valid_person): WithValidation<Json<Person>>,
-) -> String{
-    format!("{valid_person:?}")
-}
-# // Assert that handler compiles
-# axum::Router::<_, axum::body::BoxBody>::new()
-#   .route("/", axum::routing::post(handler))
-#   .with_state(())
-#   .into_make_service();
-```
-"#
-)]
+/// ### Example
+#[cfg_attr(feature = "json", doc = "```rust")]
+#[cfg_attr(not(feature = "json"), doc = "```compile_fail")]
+/// use axum::Json;
+/// use serde::{Serialize,Deserialize};
+/// use garde::Validate;
+/// use axum_garde::WithValidation;
+/// 
+/// #[derive(Debug, Serialize, Deserialize, Validate)]
+/// struct Person {
+///     #[garde(length(min = 1, max = 10))]
+///     name: String
+/// }
+/// 
+/// async fn handler(
+///     WithValidation(valid_person): WithValidation<Json<Person>>,
+/// ) -> String{
+///     format!("{valid_person:?}")
+/// }
+/// 
+/// # // Assert that handler compiles
+/// # axum::Router::new()
+/// #   .route("/", axum::routing::post(handler))
+/// #   .with_state(())
+/// #   .into_make_service();
+/// ```
 /// [`FromRequestParts`]: axum::extract::FromRequestParts
 /// [`FromRequest`]: axum::extract::FromRequest
 /// [`IntoInner`]: crate::IntoInner
@@ -83,11 +82,10 @@ where
 }
 
 #[async_trait]
-impl<State, Body, Extractor, Context> FromRequest<State, Body> for WithValidation<Extractor>
+impl<State, Extractor, Context> FromRequest<State> for WithValidation<Extractor>
 where
-    Body: Send + 'static,
     State: Send + Sync,
-    Extractor: FromRequest<State, Body> + IntoInner,
+    Extractor: FromRequest<State> + IntoInner,
     Extractor::Inner: Validate<Context = Context>,
     Context: FromRef<State>,
 {

--- a/integrations/axum_garde/src/with_validation.rs
+++ b/integrations/axum_garde/src/with_validation.rs
@@ -72,11 +72,11 @@ where
         let value = Extractor::from_request_parts(parts, state)
             .await
             .map_err(WithValidationRejection::ExtractionError)?;
+
         let ctx = FromRef::from_ref(state);
         let value = value.into_inner();
-        let value = Unvalidated::new(value)
-            .validate(&ctx)
-            .map_err(WithValidationRejection::ValidationError)?;
+        let value = Unvalidated::new(value).validate(&ctx)?;
+
         Ok(WithValidation(value))
     }
 }
@@ -95,11 +95,11 @@ where
         let value = Extractor::from_request(req, state)
             .await
             .map_err(WithValidationRejection::ExtractionError)?;
+
         let ctx = FromRef::from_ref(state);
         let value = value.into_inner();
-        let value = Unvalidated::new(value)
-            .validate(&ctx)
-            .map_err(WithValidationRejection::ValidationError)?;
+        let value = Unvalidated::new(value).validate(&ctx)?;
+
         Ok(WithValidation(value))
     }
 }


### PR DESCRIPTION
When attempting to use axum 0.7 in my project, I got an compilation error. For this reason, I did some changes to make `axum_garde` workable with the newest version of axum. If the standart extractors (such as json, form, query, etc.) functioning properly, the other dependecies([axum_yaml](https://github.com/gavrik/axum-yaml), [axum_msgpack](https://github.com/loehde/axum-msgpack)) raise errors because they should be also updated to `axum 0.7`. Nevertheless, tests with standart features were successfully passed the `cargo test -p axum_garde` command.