### PR TITLE
Rework string length rules

### DIFF
--- a/garde_derive/src/check.rs
+++ b/garde_derive/src/check.rs
@@ -350,7 +350,13 @@ fn check_rule(
         CreditCard => apply!(rule_set, CreditCard(), span),
         PhoneNumber => apply!(rule_set, PhoneNumber(), span),
         Length(v) => apply!(rule_set, Length(check_range_generic(v)?), span),
-        ByteLength(v) => apply!(rule_set, ByteLength(check_range_generic(v)?), span),
+        ByteLength(v) => {
+            #[deprecated = "the `byte_length` attribute is deprecated. Use `length` instead. (See https://github.com/jprochazk/garde/issues/84)"]
+            fn byte_length_deprecated() {}
+            byte_length_deprecated();
+
+            apply!(rule_set, ByteLength(check_range_generic(v)?), span);
+        }
         Range(v) => apply!(rule_set, Range(check_range_not_ord(v)?), span),
         Contains(v) => apply!(rule_set, Contains(v), span),
         Prefix(v) => apply!(rule_set, Prefix(v), span),


### PR DESCRIPTION
See: #84 

- [ ] Change the meaning of length to byte length
- [ ] Deprecate byte_length with a message that tells people to use length instead.
- [ ] Add a grapheme_count rule behind a unicode feature, implemented using unicode-segmentation.
- [ ] Add a char_count rule which will exist for backwards compatibility, just in case someone was depending on it counting USVs.