### PR TITLE
Validate keys

### DIFF
--- a/garde/src/rules/keys.rs
+++ b/garde/src/rules/keys.rs
@@ -1,0 +1,56 @@
+//! Key validation.
+//!
+//! ```rust
+//! #[derive(garde::Validate)]
+//! struct Test {
+//!     #[garde(keys(length(min=1)))]
+//!     v: HashMap<String, String>,
+//! }
+//! ```
+//!
+//! The entrypoint is the [`Keys`] trait. Implementing this trait for a type allows that type to be used with the `#[garde(keys(..))]` rule.
+
+use crate::error::PathComponentKind;
+
+pub fn apply<T, K, F>(field: &T, f: F)
+where
+    T: Keys<K>,
+    K: PathComponentKind,
+    F: FnMut(&K),
+{
+    field.validate_keys(f)
+}
+
+pub trait Keys<K: PathComponentKind> {
+    fn validate_keys<F>(&self, f: F)
+    where
+        F: FnMut(&K);
+}
+
+impl<K, V> Keys<K> for std::collections::HashMap<K, V>
+where
+    K: PathComponentKind,
+{
+    fn validate_keys<F>(&self, mut f: F)
+    where
+        F: FnMut(&K),
+    {
+        for key in self.keys() {
+            f(key)
+        }
+    }
+}
+
+impl<K, V> Keys<K> for std::collections::BTreeMap<K, V>
+where
+    K: PathComponentKind,
+{
+    fn validate_keys<F>(&self, mut f: F)
+    where
+        F: FnMut(&K),
+    {
+        for key in self.keys() {
+            f(key)
+        }
+    }
+}

--- a/garde/src/rules/length/bytes.rs
+++ b/garde/src/rules/length/bytes.rs
@@ -42,7 +42,6 @@ macro_rules! impl_via_len {
 }
 
 impl_via_len!(std::string::String);
-impl_via_len!(in<'a> &'a std::string::String);
 impl_via_len!(in<'a> &'a str);
 impl_via_len!(in<'a> std::borrow::Cow<'a, str>);
 impl_via_len!(std::rc::Rc<str>);

--- a/garde/src/rules/length/chars.rs
+++ b/garde/src/rules/length/chars.rs
@@ -42,7 +42,6 @@ macro_rules! impl_via_chars {
 }
 
 impl_via_chars!(std::string::String);
-impl_via_chars!(in<'a> &'a std::string::String);
 impl_via_chars!(in<'a> &'a str);
 impl_via_chars!(in<'a> std::borrow::Cow<'a, str>);
 impl_via_chars!(std::rc::Rc<str>);

--- a/garde/src/rules/length/graphemes.rs
+++ b/garde/src/rules/length/graphemes.rs
@@ -44,7 +44,6 @@ macro_rules! impl_str {
 }
 
 impl_str!(std::string::String);
-impl_str!(in<'a> &'a std::string::String);
 impl_str!(in<'a> &'a str);
 impl_str!(in<'a> std::borrow::Cow<'a, str>);
 impl_str!(std::rc::Rc<str>);

--- a/garde/src/rules/length/simple.rs
+++ b/garde/src/rules/length/simple.rs
@@ -44,7 +44,6 @@ macro_rules! impl_via_bytes {
 }
 
 impl_via_bytes!(std::string::String);
-impl_via_bytes!(in<'a> &'a std::string::String);
 impl_via_bytes!(in<'a> &'a str);
 impl_via_bytes!(in<'a> std::borrow::Cow<'a, str>);
 impl_via_bytes!(std::rc::Rc<str>);
@@ -83,7 +82,6 @@ macro_rules! impl_via_len {
 }
 
 impl_via_len!(in<T> Vec<T>);
-impl_via_len!(in<'a, T> &'a Vec<T>);
 impl_via_len!(in<'a, T> &'a [T]);
 
 impl<const N: usize, T> Simple for [T; N] {
@@ -105,10 +103,3 @@ impl_via_len!(in<T> std::collections::BTreeSet<T>);
 impl_via_len!(in<T> std::collections::VecDeque<T>);
 impl_via_len!(in<T> std::collections::BinaryHeap<T>);
 impl_via_len!(in<T> std::collections::LinkedList<T>);
-impl_via_len!(in<'a, K, V, S> &'a std::collections::HashMap<K, V, S>);
-impl_via_len!(in<'a, T, S> &'a std::collections::HashSet<T, S>);
-impl_via_len!(in<'a, K, V> &'a std::collections::BTreeMap<K, V>);
-impl_via_len!(in<'a, T> &'a std::collections::BTreeSet<T>);
-impl_via_len!(in<'a, T> &'a std::collections::VecDeque<T>);
-impl_via_len!(in<'a, T> &'a std::collections::BinaryHeap<T>);
-impl_via_len!(in<'a, T> &'a std::collections::LinkedList<T>);

--- a/garde/src/rules/length/utf16.rs
+++ b/garde/src/rules/length/utf16.rs
@@ -40,7 +40,6 @@ macro_rules! impl_str {
 }
 
 impl_str!(std::string::String);
-impl_str!(in<'a> &'a std::string::String);
 impl_str!(in<'a> &'a str);
 impl_str!(in<'a> std::borrow::Cow<'a, str>);
 impl_str!(std::rc::Rc<str>);

--- a/garde/src/rules/mod.rs
+++ b/garde/src/rules/mod.rs
@@ -9,6 +9,7 @@ pub mod credit_card;
 pub mod email;
 pub mod inner;
 pub mod ip;
+pub mod keys;
 pub mod length;
 pub mod pattern;
 #[cfg(feature = "phone-number")]

--- a/garde/tests/rules/keys.rs
+++ b/garde/tests/rules/keys.rs
@@ -1,0 +1,9 @@
+use std::collections::HashMap;
+
+use super::util;
+
+#[derive(Debug, garde::Validate)]
+struct Key<'a> {
+    #[garde(inner(length(min = 1)), keys(length(min = 1)))]
+    inner: HashMap<&'a str, &'a str>,
+}

--- a/garde/tests/rules/mod.rs
+++ b/garde/tests/rules/mod.rs
@@ -10,6 +10,7 @@ mod dive_with_rules;
 mod email;
 mod inner;
 mod ip;
+mod keys;
 mod length;
 mod multi_rule;
 mod newtype;

--- a/garde_derive/src/check.rs
+++ b/garde_derive/src/check.rs
@@ -367,14 +367,27 @@ fn check_rule(
         Suffix(v) => apply!(Suffix(v), span),
         Pattern(v) => apply!(Pattern(check_regex(v)?), span),
         Inner(v) => {
+            let mut error = None;
             if rule_set.inner.is_none() {
                 rule_set.inner = Some(Box::new(model::RuleSet::empty()));
             }
-
-            let mut error = None;
             for raw_rule in v.contents {
                 if let Err(e) = check_rule(field, raw_rule, rule_set.inner.as_mut().unwrap(), true)
                 {
+                    error.maybe_fold(e);
+                }
+            }
+            if let Some(error) = error {
+                return Err(error);
+            }
+        }
+        Keys(v) => {
+            let mut error = None;
+            if rule_set.keys.is_none() {
+                rule_set.keys = Some(Box::new(model::RuleSet::empty()));
+            }
+            for raw_rule in v.contents {
+                if let Err(e) = check_rule(field, raw_rule, rule_set.keys.as_mut().unwrap(), true) {
                     error.maybe_fold(e);
                 }
             }

--- a/garde_derive/src/model.rs
+++ b/garde_derive/src/model.rs
@@ -97,6 +97,7 @@ pub enum RawRuleKind {
     Pattern(Pattern),
     Custom(Expr),
     Inner(List<RawRule>),
+    Keys(List<RawRule>),
 }
 
 pub struct RawLength {
@@ -198,6 +199,7 @@ pub struct RuleSet {
     pub rules: BTreeSet<ValidateRule>,
     pub custom_rules: Vec<Expr>,
     pub inner: Option<Box<RuleSet>>,
+    pub keys: Option<Box<RuleSet>>,
 }
 
 impl RuleSet {
@@ -206,6 +208,7 @@ impl RuleSet {
             rules: BTreeSet::new(),
             custom_rules: Vec::new(),
             inner: None,
+            keys: None,
         }
     }
 

--- a/garde_derive/src/syntax.rs
+++ b/garde_derive/src/syntax.rs
@@ -301,6 +301,7 @@ impl Parse for model::RawRule {
             "pattern" => Pattern(content),
             "custom" => Custom(content),
             "inner" => Inner(content),
+            "keys" => Keys(content),
         }
     }
 }

--- a/garde_derive/src/syntax.rs
+++ b/garde_derive/src/syntax.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use proc_macro2::{Ident, Span};
+use proc_macro2::{Ident, Span, TokenStream};
 use syn::ext::IdentExt;
 use syn::parse::Parse;
 use syn::punctuated::Punctuated;
@@ -250,54 +250,57 @@ impl Parse for model::RawRule {
         let ident = Ident::parse_any(input)?;
 
         macro_rules! rules {
-            (($input:ident, $ident:ident) {
-                $($name:literal => $rule:ident $(($content:ident))?,)*
-            }) => {
-                match $ident.to_string().as_str() {
+            ($($name:literal => $rule:ident $(($content:ident))?,)*) => {
+                match ident.to_string().as_str() {
                     $(
                         $name => {
                             $(
                                 let $content;
-                                syn::parenthesized!($content in $input);
+                                syn::parenthesized!($content in input);
                             )?
                             Ok(model::RawRule {
-                                span: $ident.span(),
+                                span: ident.span(),
                                 kind: model::RawRuleKind::$rule $(($content.parse()?))?
                             })
                         }
                     )*
-                    _ => Err(syn::Error::new($ident.span(), "unrecognized validation rule")),
+                    _ => {
+                        if input.peek(syn::token::Paren) {
+                            let _content;
+                            syn::parenthesized!(_content in input);
+                            let _ = _content.parse::<TokenStream>()?;
+                        }
+                        Err(syn::Error::new(ident.span(), "unrecognized validation rule"))
+                    },
                 }
             };
         }
 
         rules! {
-            (input, ident) {
-                "skip" => Skip,
-                "adapt" => Adapt(content),
-                "rename" => Rename(content),
-                "message" => Message(content),
-                "code" => Code(content),
-                "dive" => Dive,
-                "required" => Required,
-                "ascii" => Ascii,
-                "alphanumeric" => Alphanumeric,
-                "email" => Email,
-                "url" => Url,
-                "ip" => Ip,
-                "ipv4" => IpV4,
-                "ipv6" => IpV6,
-                "credit_card" => CreditCard,
-                "phone_number" => PhoneNumber,
-                "length" => Length(content),
-                "range" => Range(content),
-                "contains" => Contains(content),
-                "prefix" => Prefix(content),
-                "suffix" => Suffix(content),
-                "pattern" => Pattern(content),
-                "custom" => Custom(content),
-                "inner" => Inner(content),
-            }
+            "skip" => Skip,
+            "adapt" => Adapt(content),
+            "rename" => Rename(content),
+            "message" => Message(content),
+            "code" => Code(content),
+            "dive" => Dive,
+            "required" => Required,
+            "ascii" => Ascii,
+            "alphanumeric" => Alphanumeric,
+            "email" => Email,
+            "url" => Url,
+            "ip" => Ip,
+            "ipv4" => IpV4,
+            "ipv6" => IpV6,
+            "credit_card" => CreditCard,
+            "phone_number" => PhoneNumber,
+            "length" => Length(content),
+            "range" => Range(content),
+            "contains" => Contains(content),
+            "prefix" => Prefix(content),
+            "suffix" => Suffix(content),
+            "pattern" => Pattern(content),
+            "custom" => Custom(content),
+            "inner" => Inner(content),
         }
     }
 }


### PR DESCRIPTION
Part of https://github.com/jprochazk/garde/issues/82#issuecomment-1849100734

Adds the `keys` modifier, which applies any rules onto the keys of a collection:

```rust
#[derive(garde::Validate)]
struct Key<'a> {
    #[garde(
        keys(length(min = 1)),  // apply to keys
        inner(length(min = 1)), // apply to values
    )]
    inner: HashMap<&'a str, &'a str>,
}
```

WIP:
- [x] Initial implementation in `garde_derive` + `garde`
- [ ] Improve error messages for the `keys` modifier
  - It should somehow specify that the validation failure applies to the key, not the value