### PR TITLE
Validate without context

### DIFF
--- a/garde/src/validate.rs
+++ b/garde/src/validate.rs
@@ -92,6 +92,16 @@ impl<T: Validate> Unvalidated<T> {
 
     /// Validates `self`, transforming it into a `Valid<T>`.
     /// This is the only way to create an instance of `Valid<T>`.
+    pub fn validate(self) -> Result<Valid<T>, Report>
+    where
+        <T as Validate>::Context: Default,
+    {
+        self.0.validate()?;
+        Ok(Valid(self.0))
+    }
+
+    /// Validates `self`, transforming it into a `Valid<T>`.
+    /// This is the only way to create an instance of `Valid<T>`.
     pub fn validate_with(self, ctx: &<T as Validate>::Context) -> Result<Valid<T>, Report> {
         self.0.validate_with(ctx)?;
         Ok(Valid(self.0))

--- a/garde/tests/rules/select.rs
+++ b/garde/tests/rules/select.rs
@@ -21,7 +21,7 @@ fn select_macro() {
         identifiers: vec![UserIdentifier { id: 10 }, UserIdentifier { id: 20 }],
     };
 
-    let report = v.validate(&()).unwrap_err();
+    let report = v.validate().unwrap_err();
     {
         let errors: Vec<String> = garde::select!(report, identifiers[0])
             .map(|e| e.to_string())

--- a/garde/tests/rules/url.rs
+++ b/garde/tests/rules/url.rs
@@ -107,5 +107,5 @@ fn url_valid_wrapper() {
         field: "htt ps://www.youtube.com/watch?v=dQw4w9WgXcQ",
         inner: &["htt ps://www.youtube.com/watch?v=dQw4w9WgXcQ"],
     };
-    println!("{:?}", value.validate(&()).unwrap_err());
+    println!("{:?}", value.validate().unwrap_err());
 }

--- a/garde/tests/rules/util.rs
+++ b/garde/tests/rules/util.rs
@@ -8,7 +8,7 @@ use owo_colors::OwoColorize;
 pub fn check_ok<T: Validate + Debug>(cases: &[T], ctx: &T::Context) {
     let mut some_failed = false;
     for case in cases {
-        if let Err(report) = case.validate(ctx) {
+        if let Err(report) = case.validate_with(ctx) {
             eprintln!(
                 "{} input: {case:?}, errors: [{}]",
                 "FAIL".red(),
@@ -32,7 +32,7 @@ pub fn __check_fail<T: Validate + Debug>(cases: &[T], ctx: &T::Context) -> Strin
     let mut some_success = false;
     let mut snapshot = String::new();
     for case in cases {
-        if let Err(report) = case.validate(ctx) {
+        if let Err(report) = case.validate_with(ctx) {
             writeln!(&mut snapshot, "{case:#?}").unwrap();
             write!(&mut snapshot, "{report}").unwrap();
             writeln!(&mut snapshot).unwrap();

--- a/integrations/axum_garde/src/with_validation.rs
+++ b/integrations/axum_garde/src/with_validation.rs
@@ -75,7 +75,7 @@ where
 
         let ctx = FromRef::from_ref(state);
         let value = value.into_inner();
-        let value = Unvalidated::new(value).validate(&ctx)?;
+        let value = Unvalidated::new(value).validate_with(&ctx)?;
 
         Ok(WithValidation(value))
     }
@@ -98,7 +98,7 @@ where
 
         let ctx = FromRef::from_ref(state);
         let value = value.into_inner();
-        let value = Unvalidated::new(value).validate(&ctx)?;
+        let value = Unvalidated::new(value).validate_with(&ctx)?;
 
         Ok(WithValidation(value))
     }


### PR DESCRIPTION
This PR demonstrates how to avoid having to create two different traits, one with context and the other one without it.

It doesn't require the context to implement the `Default` trait, but if it do so it will have an additional `validate` function without the context, and it won't have it if the context doesn't implement the trait.

Closes #39 and closes #100.

This is a breaking change, so the minor version must be increased on the next release.