### PR TITLE
Add Report::into_inner

### DIFF
--- a/garde/src/error.rs
+++ b/garde/src/error.rs
@@ -45,6 +45,11 @@ impl Report {
     pub fn is_empty(&self) -> bool {
         self.errors.is_empty()
     }
+
+    /// Converts into the inner validation errors.
+    pub fn into_inner(self) -> Vec<(Path, Error)> {
+        self.errors
+    }
 }
 
 impl std::fmt::Display for Report {


### PR DESCRIPTION
Allows to retrieve the inner `Vec` of errors in the report, in case anyone needs to process them in a custom way.