### PR TITLE
Update crates and UI test

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -104,6 +104,7 @@ unlicensed = "deny"
 allow = [
     "MIT",
     "Apache-2.0",
+    "Unicode-3.0",
     "Unicode-DFS-2016",
     "Unlicense",
     "BSD-3-Clause",

--- a/garde/Cargo.toml
+++ b/garde/Cargo.toml
@@ -50,7 +50,7 @@ regex = { version = "1", default-features = false, features = [
     "std",
 ], optional = true }
 once_cell = { version = "1", optional = true }
-idna = { version = "0.3", optional = true }
+idna = { version = "1", optional = true }
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 js-sys = { version = "0.3", optional = true }
@@ -58,7 +58,7 @@ js-sys = { version = "0.3", optional = true }
 [dev-dependencies]
 trybuild = { version = "1.0" }
 insta = { version = "1.29" }
-owo-colors = { version = "3.5.0" }
+owo-colors = { version = "4" }
 glob = "0.3.1"
 serde_json = { version = "1.0.112", features = ["preserve_order"] }
 

--- a/garde/src/rules/email.rs
+++ b/garde/src/rules/email.rs
@@ -15,6 +15,8 @@
 use std::fmt::Display;
 use std::str::FromStr;
 
+use idna::AsciiDenyList;
+
 use super::pattern::Matcher;
 use super::AsStr;
 use crate::error::Error;
@@ -121,7 +123,7 @@ pub fn parse_email(s: &str) -> Result<(), InvalidEmail> {
 
         #[cfg(feature = "email-idna")]
         {
-            match idna::domain_to_ascii(domain) {
+            match idna::domain_to_ascii_cow(domain.as_bytes(), AsciiDenyList::URL) {
                 Ok(domain) => {
                     if !is_valid_domain(&domain) {
                         return Err(InvalidEmail::InvalidDomain);

--- a/garde/tests/ui/compile-fail/pattern_mismatched_types.stderr
+++ b/garde/tests/ui/compile-fail/pattern_mismatched_types.stderr
@@ -8,8 +8,8 @@ error[E0277]: the trait bound `&str: Matcher` is not satisfied
   |                     ^^^ the trait `Matcher` is not implemented for `&str`
   |
   = help: the following other types implement trait `Matcher`:
-            once_cell::sync::Lazy<T>
             Regex
+            once_cell::sync::Lazy<T>
 note: required by a bound in `garde::rules::pattern::apply`
  --> src/rules/pattern.rs
   |

--- a/integrations/axum_garde/Cargo.toml
+++ b/integrations/axum_garde/Cargo.toml
@@ -36,10 +36,10 @@ garde = { version = "0.19.0", path = "../../garde", features = [
   "derive",
 ] }
 axum = { version = "0.7", features = ["default", "macros"] }
-axum-test = { version = "14.1" }
+axum-test = { version = "15" }
 tokio = { version = "1.28", features = ["full"] }
 prost = { version = "0.12" }
-rstest = { version = "0.18" }
+rstest = { version = "0.21" }
 speculoos = { version = "0.11" }
 
 [[example]]

--- a/integrations/axum_garde/Cargo.toml
+++ b/integrations/axum_garde/Cargo.toml
@@ -36,7 +36,7 @@ garde = { version = "0.19.0", path = "../../garde", features = [
   "derive",
 ] }
 axum = { version = "0.7", features = ["default", "macros"] }
-axum-test = { version = "15" }
+axum-test = { version = "14.10" }
 tokio = { version = "1.28", features = ["full"] }
 prost = { version = "0.12" }
 rstest = { version = "0.21" }

--- a/integrations/axum_garde/src/lib.rs
+++ b/integrations/axum_garde/src/lib.rs
@@ -12,7 +12,6 @@
     clippy::needless_borrow,
     clippy::match_wildcard_for_single_variants,
     clippy::if_let_mutex,
-    clippy::mismatched_target_os,
     clippy::await_holding_lock,
     clippy::match_on_vec_items,
     clippy::imprecise_flops,

--- a/xtask/Cargo.lock
+++ b/xtask/Cargo.lock
@@ -226,15 +226,15 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
 
 [[package]]
 name = "toml_edit"
-version = "0.19.14"
+version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
+checksum = "f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38"
 dependencies = [
  "indexmap",
  "kstring",
@@ -271,9 +271,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "winnow"
-version = "0.5.15"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2e3184b9c4e92ad5167ca73039d0c42476302ab603e2fec4487511f38ccefc"
+checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
 dependencies = [
  "memchr",
 ]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -15,6 +15,6 @@ anyhow = { version = "1.0.72", features = ["backtrace"] }
 argp = "0.3"
 glob = { version = "0.3.1", default-features = false }
 semver = "1.0.18"
-toml_edit = { version = "0.19.14", features = ["perf"] }
+toml_edit = { version = "0.22.14", features = ["perf"] }
 
 [workspace]

--- a/xtask/src/crates.rs
+++ b/xtask/src/crates.rs
@@ -3,13 +3,13 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use semver::{BuildMetadata, Prerelease};
-use toml_edit::Document;
+use toml_edit::DocumentMut;
 
 use crate::Result;
 
 pub struct Crate {
     path: PathBuf,
-    doc: Document,
+    doc: DocumentMut,
 }
 
 impl Crate {
@@ -22,7 +22,7 @@ impl Crate {
     pub fn from_str(path: impl AsRef<Path>, source: &str) -> Result<Self> {
         Ok(Self {
             path: path.as_ref().to_path_buf(),
-            doc: source.parse::<Document>()?,
+            doc: source.parse::<DocumentMut>()?,
         })
     }
 


### PR DESCRIPTION
This PR just updates a few crates that were out of date.  

List of out-of-date crates:

- `axum-test` (dev dependency)
- `idna` (actually used but not in the public interface)
- `owo-colors` (dev dependency)

It also (begrudgingly) updates a UI test because the newest stable changes the order of the types yet again.

---

The `idna` update also uses the new `domain_to_ascii_cow` API, meaning no allocations if the domain is already in its ASCII representation.

It also uses the `AsciiDenyList::URL` as recomended by the `idna` docs. Not sure if this potentially breaks something for people? I guess this is a case of "test by scream", they'll complain if something breaks.