### PR TITLE
fix: validate phone number

### DIFF
--- a/garde/src/rules/phone_number.rs
+++ b/garde/src/rules/phone_number.rs
@@ -19,34 +19,35 @@ use super::AsStr;
 use crate::error::Error;
 
 pub fn apply<T: PhoneNumber>(v: &T, _: ()) -> Result<(), Error> {
-    if let Err(e) = v.validate_phone_number() {
-        return Err(Error::new(format!("not a valid phone number: {e}")));
+    match v.validate_phone_number() {
+        Ok(true) => Ok(()),
+        Ok(false) => Err(Error::new("not a valid phone number")),
+        Err(e) => Err(Error::new(format!("not a valid phone number: {e}"))),
     }
-    Ok(())
 }
 
 pub trait PhoneNumber {
     type Error: Display;
 
-    fn validate_phone_number(&self) -> Result<(), Self::Error>;
+    fn validate_phone_number(&self) -> Result<bool, Self::Error>;
 }
 
 impl<T: AsStr> PhoneNumber for T {
     type Error = phonenumber::ParseError;
 
-    fn validate_phone_number(&self) -> Result<(), Self::Error> {
-        let _ = phonenumber::PhoneNumber::from_str(self.as_str())?;
-        Ok(())
+    fn validate_phone_number(&self) -> Result<bool, Self::Error> {
+        let number = phonenumber::PhoneNumber::from_str(self.as_str())?;
+        Ok(number.is_valid())
     }
 }
 
 impl<T: PhoneNumber> PhoneNumber for Option<T> {
     type Error = T::Error;
 
-    fn validate_phone_number(&self) -> Result<(), Self::Error> {
+    fn validate_phone_number(&self) -> Result<bool, Self::Error> {
         match self {
             Some(value) => value.validate_phone_number(),
-            None => Ok(()),
+            None => Ok(true),
         }
     }
 }


### PR DESCRIPTION
Closes #119 by validating the phone numbers.

This change does modify a public trait, it can be refactored to avoid that but I don't see it as an issue as it's still pre-1.0