### PR TITLE
Improved compiler errors when feature flags are missing

### DIFF
--- a/garde/Cargo.toml
+++ b/garde/Cargo.toml
@@ -23,6 +23,8 @@ full = [
     "unicode",
 ]
 
+# NOTE: When adding new feature flags for validation rules you will likely want to add the corresponding
+#       feature flag in garde_derive to give better compiler error messages.
 serde = ["dep:serde", "compact_str/serde", "smallvec/serde"]
 derive = ["dep:garde_derive"]
 url = ["dep:url", "garde_derive?/url"]

--- a/garde/Cargo.toml
+++ b/garde/Cargo.toml
@@ -25,11 +25,11 @@ full = [
 
 serde = ["dep:serde", "compact_str/serde", "smallvec/serde"]
 derive = ["dep:garde_derive"]
-url = ["dep:url"]
+url = ["dep:url", "garde_derive?/url"]
 unicode = ["dep:unicode-segmentation"]
-credit-card = ["dep:card-validate"]
-phone-number = ["dep:phonenumber"]
-email = ["regex"]
+credit-card = ["dep:card-validate", "garde_derive?/credit-card"]
+phone-number = ["dep:phonenumber", "garde_derive?/phone-number"]
+email = ["regex", "garde_derive?/email"]
 email-idna = ["dep:idna"]
 regex = ["dep:regex", "dep:once_cell", "garde_derive?/regex"]
 pattern = ["regex"] # for backward compatibility with <0.14.0

--- a/garde_derive/Cargo.toml
+++ b/garde_derive/Cargo.toml
@@ -23,6 +23,7 @@ phone-number = []
 syn = { version = "2", features = ["full", "derive"] }
 quote = { version = "1" }
 proc-macro2 = { version = "1" }
+proc-macro-error = "1"
 regex = { version = "1", default-features = false, features = [
   "std",
 ], optional = true }

--- a/garde_derive/Cargo.toml
+++ b/garde_derive/Cargo.toml
@@ -23,7 +23,6 @@ phone-number = []
 syn = { version = "2", features = ["full", "derive"] }
 quote = { version = "1" }
 proc-macro2 = { version = "1" }
-proc-macro-error = "1"
 regex = { version = "1", default-features = false, features = [
   "std",
 ], optional = true }

--- a/garde_derive/Cargo.toml
+++ b/garde_derive/Cargo.toml
@@ -14,6 +14,10 @@ proc-macro = true
 
 [features]
 regex = ["dep:regex"]
+email = []
+url = []
+credit-card = []
+phone-number = []
 
 [dependencies]
 syn = { version = "2", features = ["full", "derive"] }

--- a/garde_derive/Cargo.toml
+++ b/garde_derive/Cargo.toml
@@ -13,6 +13,7 @@ readme = "../README.md"
 proc-macro = true
 
 [features]
+# NOTE: When adding new validation rule feature flags, don't forget to add checking to `src/syntax.rs`
 regex = ["dep:regex"]
 email = []
 url = []

--- a/garde_derive/src/lib.rs
+++ b/garde_derive/src/lib.rs
@@ -5,11 +5,9 @@ mod syntax;
 mod util;
 
 use proc_macro::{Delimiter, Literal, Span, TokenStream, TokenTree};
-use proc_macro_error::proc_macro_error;
 use quote::quote;
 use syn::DeriveInput;
 
-#[proc_macro_error]
 #[proc_macro_derive(Validate, attributes(garde))]
 pub fn derive_validate(input: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(input as DeriveInput);

--- a/garde_derive/src/lib.rs
+++ b/garde_derive/src/lib.rs
@@ -5,9 +5,11 @@ mod syntax;
 mod util;
 
 use proc_macro::{Delimiter, Literal, Span, TokenStream, TokenTree};
+use proc_macro_error::proc_macro_error;
 use quote::quote;
 use syn::DeriveInput;
 
+#[proc_macro_error]
 #[proc_macro_derive(Validate, attributes(garde))]
 pub fn derive_validate(input: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(input as DeriveInput);

--- a/garde_derive/src/syntax.rs
+++ b/garde_derive/src/syntax.rs
@@ -272,27 +272,38 @@ impl Parse for model::RawRule {
         }
 
         macro_rules! error_if_missing_feature {
-            ($other:expr) => {
-                #[cfg(not(feature = $other))]
-                panic!(concat!("Missing feature flag ", stringify!($other)));
+            ($rule:expr, $feature:expr) => {
+                #[cfg(not(feature = $feature))]
+                proc_macro_error::abort!(
+                    ident,
+                    concat!(
+                        "Validation rule `",
+                        $rule,
+                        "` not found. Did you forget to add the `",
+                        $feature,
+                        "` feature flag?"
+                    )
+                );
             };
         }
 
+        // abort!(ident, "`parse` must have exactly one argument");
+
         match ident.to_string().as_str() {
             "email" => {
-                error_if_missing_feature!("email");
+                error_if_missing_feature!("email", "email");
             }
             "url" => {
-                error_if_missing_feature!("url");
+                error_if_missing_feature!("url", "url");
             }
             "credit_card" => {
-                error_if_missing_feature!("credit-card");
+                error_if_missing_feature!("credit_card", "credit-card");
             }
             "phone_number" => {
-                error_if_missing_feature!("phone-number");
+                error_if_missing_feature!("phone_number", "phone-number");
             }
             "regex" => {
-                error_if_missing_feature!("regex");
+                error_if_missing_feature!("regex", "regex");
             }
             _ => {}
         }

--- a/garde_derive/src/syntax.rs
+++ b/garde_derive/src/syntax.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeMap;
 
 use proc_macro2::{Ident, Span};
-use quote::IdentFragment;
 use syn::ext::IdentExt;
 use syn::parse::Parse;
 use syn::punctuated::Punctuated;

--- a/garde_derive/src/syntax.rs
+++ b/garde_derive/src/syntax.rs
@@ -271,6 +271,32 @@ impl Parse for model::RawRule {
             };
         }
 
+        macro_rules! error_if_missing_feature {
+            ($other:expr) => {
+                #[cfg(not(feature = $other))]
+                panic!(concat!("Missing feature flag ", stringify!($other)));
+            };
+        }
+
+        match ident.to_string().as_str() {
+            "email" => {
+                error_if_missing_feature!("email");
+            }
+            "url" => {
+                error_if_missing_feature!("url");
+            }
+            "credit_card" => {
+                error_if_missing_feature!("credit-card");
+            }
+            "phone_number" => {
+                error_if_missing_feature!("phone-number");
+            }
+            "regex" => {
+                error_if_missing_feature!("regex");
+            }
+            _ => {}
+        }
+
         rules! {
             (input, ident) {
                 "skip" => Skip,

--- a/garde_derive/src/syntax.rs
+++ b/garde_derive/src/syntax.rs
@@ -287,8 +287,6 @@ impl Parse for model::RawRule {
             };
         }
 
-        // abort!(ident, "`parse` must have exactly one argument");
-
         match ident.to_string().as_str() {
             "email" => {
                 error_if_missing_feature!("email", "email");

--- a/garde_derive/src/syntax.rs
+++ b/garde_derive/src/syntax.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 
 use proc_macro2::{Ident, Span};
+use quote::IdentFragment;
 use syn::ext::IdentExt;
 use syn::parse::Parse;
 use syn::punctuated::Punctuated;
@@ -274,16 +275,16 @@ impl Parse for model::RawRule {
         macro_rules! error_if_missing_feature {
             ($rule:expr, $feature:expr) => {
                 #[cfg(not(feature = $feature))]
-                proc_macro_error::abort!(
-                    ident,
+                return Err(syn::Error::new(
+                    ident.span(),
                     concat!(
                         "Validation rule `",
                         $rule,
                         "` not found. Did you forget to add the `",
                         $feature,
                         "` feature flag?"
-                    )
-                );
+                    ),
+                ));
             };
         }
 


### PR DESCRIPTION
This PR adds improved compiler errors when features flags are not enabled.

For example:
Given this following struct, 
```rust
#[derive(Validate)]
struct User<'a> {
    #[garde(email)]
    email: &'a str,
}
```

without the `email` feature flag enabled, the following error message is output.
```
error: Validation rule `email` not found. Did you forget to add the `email` feature flag?
  --> src/main.rs:23:13
   |
23 |     #[garde(email)]
   |             ^^^^^
```
---


See original issue here https://github.com/jprochazk/garde/issues/9
