### PR TITLE
Implement `Matcher` for `std::sync::LazyLock<T>`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         include:
           - build: pinned
             os: ubuntu-20.04
-            rust: 1.72
+            rust: "1.80"
             # Fails on pinned version because the output changed,
             # so we're excluding it, but it's still tested on stable and nightly.
             EXCLUDE_UI_TESTS: "pattern_mismatched_types,newtype,matches_unknown_field"

--- a/README.md
+++ b/README.md
@@ -518,8 +518,6 @@ Contributing to `garde` only requires a somewhat recent version of [`Rust`](http
 
 This repository also makes use of the following tools, but they are optional:
 - [`insta`](https://insta.rs/) for snapshot testing ([tests/rules](./garde_derive_tests/tests/rules/)).
-- [`just`](https://just.systems/) for running recipes defined in the [`justfile`](./justfile).
-  Run `just -l` to see what recipes are available.
 
 ### License
 

--- a/garde/tests/rules/pattern.rs
+++ b/garde/tests/rules/pattern.rs
@@ -3,11 +3,14 @@ use regex::Regex;
 use super::util;
 
 mod sub {
+    use std::sync::LazyLock;
+
     use once_cell::sync::Lazy;
 
     use super::*;
 
-    pub static LAZY_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"^abcd|efgh$").unwrap());
+    pub static LAZY_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^abcd|efgh$").unwrap());
+    pub static LAZY_RE_ONCE_CELL: Lazy<Regex> = Lazy::new(|| Regex::new(r"^abcd|efgh$").unwrap());
 }
 
 #[derive(Debug, garde::Validate)]
@@ -17,6 +20,9 @@ struct Test<'a> {
 
     #[garde(pattern(sub::LAZY_RE))]
     field_path: &'a str,
+
+    #[garde(pattern(sub::LAZY_RE_ONCE_CELL))]
+    field_path_once_cell: &'a str,
 
     #[garde(pattern(create_regex()))]
     field_call: &'a str,
@@ -46,12 +52,14 @@ fn pattern_valid() {
             Test {
                 field: "abcd",
                 field_path: "abcd",
+                field_path_once_cell: "abcd",
                 field_call: "abcd",
                 inner: &["abcd"],
             },
             Test {
                 field: "efgh",
                 field_path: "efgh",
+                field_path_once_cell: "abcd",
                 field_call: "efgh",
                 inner: &["efgh"],
             },
@@ -68,12 +76,14 @@ fn pattern_invalid() {
             Test {
                 field: "dcba",
                 field_path: "dcba",
+                field_path_once_cell: "abcd",
                 field_call: "dcba",
                 inner: &["dcba"]
             },
             Test {
                 field: "hgfe",
                 field_path: "hgfe",
+                field_path_once_cell: "abcd",
                 field_call: "hgfe",
                 inner: &["hgfe"]
             }

--- a/garde/tests/rules/snapshots/rules__rules__pattern__pattern_invalid.snap
+++ b/garde/tests/rules/snapshots/rules__rules__pattern__pattern_invalid.snap
@@ -5,6 +5,7 @@ expression: snapshot
 Test {
     field: "dcba",
     field_path: "dcba",
+    field_path_once_cell: "abcd",
     field_call: "dcba",
     inner: [
         "dcba",
@@ -18,6 +19,7 @@ inner[0]: does not match pattern /^abcd|efgh$/
 Test {
     field: "hgfe",
     field_path: "hgfe",
+    field_path_once_cell: "abcd",
     field_call: "hgfe",
     inner: [
         "hgfe",
@@ -27,5 +29,3 @@ field: does not match pattern /^abcd|efgh$/
 field_call: does not match pattern /^abcd|efgh$/
 field_path: does not match pattern /^abcd|efgh$/
 inner[0]: does not match pattern /^abcd|efgh$/
-
-

--- a/garde/tests/ui/compile-fail/pattern_mismatched_types.stderr
+++ b/garde/tests/ui/compile-fail/pattern_mismatched_types.stderr
@@ -8,6 +8,7 @@ error[E0277]: the trait bound `&str: Matcher` is not satisfied
   |                     ^^^ the trait `Matcher` is not implemented for `&str`
   |
   = help: the following other types implement trait `Matcher`:
+            LazyLock<T>
             Regex
             once_cell::sync::Lazy<T>
 note: required by a bound in `garde::rules::pattern::apply`


### PR DESCRIPTION
Resolves: #129 

⚠️ This bumps MSRV to 1.80.

`Matcher` impl for `std::sync::LazyLock<T>` isn't gated behind `regex` feature because it doesn't need `once_cell` dependency.

Would be nice to phase out `once_cell` completely but i'm not sure how to do that without breaking existing feature flags
