### PR TITLE
Replace once_cell for std

### DIFF
--- a/garde/Cargo.toml
+++ b/garde/Cargo.toml
@@ -31,7 +31,7 @@ credit-card = ["dep:card-validate"]
 phone-number = ["dep:phonenumber"]
 email = ["regex"]
 email-idna = ["dep:idna"]
-regex = ["dep:regex", "dep:once_cell", "garde_derive?/regex"]
+regex = ["dep:regex", "garde_derive?/regex"]
 pattern = ["regex"] # for backward compatibility with <0.14.0
 js-sys = ["dep:js-sys"]
 
@@ -49,7 +49,6 @@ phonenumber = { version = "0.3.2+8.13.9", optional = true }
 regex = { version = "1", default-features = false, features = [
     "std",
 ], optional = true }
-once_cell = { version = "1", optional = true }
 idna = { version = "1", optional = true }
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]

--- a/garde/src/rules/pattern.rs
+++ b/garde/src/rules/pattern.rs
@@ -144,9 +144,9 @@ pub mod regex {
         }
     }
 
-    impl<T: Matcher> Matcher for once_cell::sync::Lazy<T> {
+    impl<T: Matcher> Matcher for std::sync::LazyLock<T> {
         fn is_match(&self, haystack: &str) -> bool {
-            once_cell::sync::Lazy::force(self).is_match(haystack)
+            std::sync::LazyLock::force(self).is_match(haystack)
         }
     }
 
@@ -156,13 +156,13 @@ pub mod regex {
         }
     }
 
-    impl<T: AsStr> AsStr for once_cell::sync::Lazy<T> {
+    impl<T: AsStr> AsStr for std::sync::LazyLock<T> {
         fn as_str(&self) -> &str {
-            once_cell::sync::Lazy::force(self).as_str()
+            std::sync::LazyLock::force(self).as_str()
         }
     }
 
-    pub type StaticPattern = once_cell::sync::Lazy<Regex>;
+    pub type StaticPattern = std::sync::LazyLock<Regex>;
 
     #[macro_export]
     macro_rules! __init_pattern {

--- a/garde/tests/rules/pattern.rs
+++ b/garde/tests/rules/pattern.rs
@@ -3,11 +3,11 @@ use regex::Regex;
 use super::util;
 
 mod sub {
-    use once_cell::sync::Lazy;
+    use std::sync::LazyLock;
 
     use super::*;
 
-    pub static LAZY_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"^abcd|efgh$").unwrap());
+    pub static LAZY_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^abcd|efgh$").unwrap());
 }
 
 #[derive(Debug, garde::Validate)]


### PR DESCRIPTION
As of Rust 1.80, `once_cell` has been stabilized and is now part of std, this PR removes that dependency.