### PR TITLE
fix: exclude `cfg` of `js-sys` from macro expansion

### DIFF
--- a/garde/Cargo.toml
+++ b/garde/Cargo.toml
@@ -34,7 +34,7 @@ email = ["regex"]
 email-idna = ["dep:idna"]
 regex = ["dep:regex", "dep:once_cell", "garde_derive?/regex"]
 pattern = ["regex"]                                           # for backward compatibility with <0.14.0
-js-sys = ["dep:js-sys"]
+js-sys = ["dep:js-sys", "garde_derive?/js-sys"]
 rust_decimal = ["dep:rust_decimal"]
 
 [dependencies]

--- a/garde_derive/Cargo.toml
+++ b/garde_derive/Cargo.toml
@@ -15,6 +15,7 @@ proc-macro = true
 
 [features]
 regex = ["dep:regex"]
+js-sys = []
 
 [dependencies]
 syn = { version = "2", features = ["full", "derive"] }


### PR DESCRIPTION
Exclude `cfg` about `js-sys` feature flag from the expanded code.

Fix #140.