### PR TITLE
Allow an optional context when using dive

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ if let Err(e) = data.validate() {
 
 Additional notes:
 - `required` is only available for `Option` fields.
-- `dive` accepts an optional context: `#[garde(dive(&self.other_field))]`
+- `dive` accepts an optional context: `#[garde(dive(self.other_field))]`
 - The `<mode>` argument for `length` is [explained here](#length-modes)
 - For `length` and `range`:
   - If `equal` is defined, `min` and `max` must be omitted.

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ if let Err(e) = data.validate() {
 
 Additional notes:
 - `required` is only available for `Option` fields.
+- `dive` accepts an optional context: `#[garde(dive(&self.other_field))]`
 - The `<mode>` argument for `length` is [explained here](#length-modes)
 - For `length` and `range`:
   - If `equal` is defined, `min` and `max` must be omitted.

--- a/garde/tests/rules/dive_with_ctx.rs
+++ b/garde/tests/rules/dive_with_ctx.rs
@@ -13,7 +13,7 @@ struct Test<'a> {
     min: usize,
     #[garde(skip)]
     max: usize,
-    #[garde(dive(&(self.min, self.max)))]
+    #[garde(dive((self.min, self.max)))]
     inner: Inner<'a>,
 }
 

--- a/garde/tests/rules/dive_with_ctx.rs
+++ b/garde/tests/rules/dive_with_ctx.rs
@@ -1,0 +1,53 @@
+use super::util;
+
+#[derive(Clone, Copy, Debug, garde::Validate)]
+#[garde(context((usize, usize) as ctx))]
+struct Inner<'a> {
+    #[garde(length(min = ctx.0, max = ctx.1))]
+    field: &'a str,
+}
+
+#[derive(Debug, garde::Validate)]
+struct Test<'a> {
+    #[garde(skip)]
+    min: usize,
+    #[garde(skip)]
+    max: usize,
+    #[garde(dive(&(self.min, self.max)))]
+    inner: Inner<'a>,
+}
+
+#[derive(Debug, garde::Validate)]
+#[garde(context((usize, usize)))]
+struct Test2<'a> {
+    #[garde(dive)]
+    inner: Inner<'a>,
+}
+
+#[test]
+fn valid() {
+    let inner = Inner { field: "asdf" };
+    util::check_ok(&[Test2 { inner }], &(1, 5));
+    util::check_ok(
+        &[Test {
+            min: 1,
+            max: 5,
+            inner,
+        }],
+        &(),
+    );
+}
+
+#[test]
+fn invalid() {
+    let inner = Inner { field: "asdfgh" };
+    util::check_fail!(&[Test2 { inner }], &(1, 5));
+    util::check_fail!(
+        &[Test {
+            min: 1,
+            max: 5,
+            inner,
+        }],
+        &(),
+    );
+}

--- a/garde/tests/rules/mod.rs
+++ b/garde/tests/rules/mod.rs
@@ -6,6 +6,7 @@ mod contains;
 mod credit_card;
 mod custom;
 mod dive;
+mod dive_with_ctx;
 mod dive_with_rules;
 mod email;
 mod inner;

--- a/garde/tests/rules/snapshots/rules__rules__dive_with_ctx__invalid-2.snap
+++ b/garde/tests/rules/snapshots/rules__rules__dive_with_ctx__invalid-2.snap
@@ -1,0 +1,13 @@
+---
+source: garde/tests/./rules/dive_with_ctx.rs
+expression: snapshot
+snapshot_kind: text
+---
+Test {
+    min: 1,
+    max: 5,
+    inner: Inner {
+        field: "asdfgh",
+    },
+}
+inner.field: length is greater than 5

--- a/garde/tests/rules/snapshots/rules__rules__dive_with_ctx__invalid.snap
+++ b/garde/tests/rules/snapshots/rules__rules__dive_with_ctx__invalid.snap
@@ -1,0 +1,11 @@
+---
+source: garde/tests/./rules/dive_with_ctx.rs
+expression: snapshot
+snapshot_kind: text
+---
+Test2 {
+    inner: Inner {
+        field: "asdfgh",
+    },
+}
+inner.field: length is greater than 5

--- a/garde_derive/src/check.rs
+++ b/garde_derive/src/check.rs
@@ -264,7 +264,7 @@ fn check_field(field: model::Field, options: &model::Options) -> syn::Result<mod
         }
     }
 
-    if let Some(span) = field.dive {
+    if let Some((span, _)) = field.dive {
         if field.rule_set.inner.is_some() {
             error.maybe_fold(syn::Error::new(
                 span,
@@ -339,7 +339,7 @@ fn check_rule(
         Rename(alias) => apply!(alias = alias.value, span),
         // Message(message) => apply!(message = message, span),
         Code(code) => apply!(code = code.value, span),
-        Dive => apply!(dive = span, span),
+        Dive(ctx) => apply!(dive = (span, ctx), span),
         Custom(custom) => rule_set.custom_rules.push(custom),
         Required => apply!(Required(), span),
         Ascii => apply!(Ascii(), span),

--- a/garde_derive/src/emit.rs
+++ b/garde_derive/src/emit.rs
@@ -392,7 +392,7 @@ where
                 (Some((_, Some(ctx))), None) => Some(quote! {
                     ::garde::validate::Validate::validate_into(
                         &*__garde_binding,
-                        #ctx,
+                        &#ctx,
                         &mut __garde_path,
                         __garde_report,
                     );

--- a/garde_derive/src/emit.rs
+++ b/garde_derive/src/emit.rs
@@ -381,10 +381,18 @@ where
                 false => None,
             };
             let inner = match (&field.dive, &field.rule_set.inner) {
-                (Some(..), None) => Some(quote! {
+                (Some((_, None)), None) => Some(quote! {
                     ::garde::validate::Validate::validate_into(
                         &*__garde_binding,
                         __garde_user_ctx,
+                        &mut __garde_path,
+                        __garde_report,
+                    );
+                }),
+                (Some((_, Some(ctx))), None) => Some(quote! {
+                    ::garde::validate::Validate::validate_into(
+                        &*__garde_binding,
+                        #ctx,
                         &mut __garde_path,
                         __garde_report,
                     );

--- a/garde_derive/src/model.rs
+++ b/garde_derive/src/model.rs
@@ -78,7 +78,7 @@ pub enum RawRuleKind {
     Rename(Str),
     // Message(Message),
     Code(Str),
-    Dive,
+    Dive(Option<Expr>),
     Required,
     Ascii,
     Alphanumeric,
@@ -184,7 +184,7 @@ pub struct ValidateField {
     // pub message: Option<Message>,
     pub code: Option<String>,
 
-    pub dive: Option<Span>,
+    pub dive: Option<(Span, Option<Expr>)>,
     pub rule_set: RuleSet,
 }
 


### PR DESCRIPTION
This PR closes #142 

The macro is backwards-compatible, so it just requires a minor version update.