### PR TITLE
Implement length rule for urls

### DIFF
--- a/garde/src/rules/url.rs
+++ b/garde/src/rules/url.rs
@@ -52,3 +52,36 @@ impl<T: Url> Url for Option<T> {
         }
     }
 }
+
+impl super::length::HasSimpleLength for url::Url {
+    fn length(&self) -> usize {
+        self.as_str().len()
+    }
+}
+
+impl super::length::HasChars for url::Url {
+    fn num_chars(&self) -> usize {
+        self.as_str().chars().count()
+    }
+}
+
+#[cfg(feature = "unicode")]
+impl super::length::HasGraphemes for url::Url {
+    fn num_graphemes(&self) -> usize {
+        use unicode_segmentation::UnicodeSegmentation;
+
+        self.as_str().graphemes(true).count()
+    }
+}
+
+impl super::length::HasBytes for url::Url {
+    fn num_bytes(&self) -> usize {
+        self.as_str().len()
+    }
+}
+
+impl super::length::HasUtf16CodeUnits for url::Url {
+    fn num_code_units(&self) -> usize {
+        self.as_str().encode_utf16().count()
+    }
+}

--- a/garde/tests/rules/snapshots/rules__rules__url__length__url_enum_invalid.snap
+++ b/garde/tests/rules/snapshots/rules__rules__url__length__url_enum_invalid.snap
@@ -1,0 +1,139 @@
+---
+source: garde/tests/./rules/url.rs
+expression: snapshot
+---
+Struct {
+    field: Url {
+        scheme: "https",
+        cannot_be_a_base: false,
+        username: "",
+        password: None,
+        host: Some(
+            Domain(
+                "www.youtube.com",
+            ),
+        ),
+        port: None,
+        path: "/",
+        query: None,
+        fragment: None,
+    },
+    v: Struct {
+        default: Url {
+            scheme: "https",
+            cannot_be_a_base: false,
+            username: "",
+            password: None,
+            host: Some(
+                Domain(
+                    "www.youtube.com",
+                ),
+            ),
+            port: None,
+            path: "/",
+            query: None,
+            fragment: None,
+        },
+        simple: Url {
+            scheme: "https",
+            cannot_be_a_base: false,
+            username: "",
+            password: None,
+            host: Some(
+                Domain(
+                    "www.youtube.com",
+                ),
+            ),
+            port: None,
+            path: "/",
+            query: None,
+            fragment: None,
+        },
+        bytes: Url {
+            scheme: "https",
+            cannot_be_a_base: false,
+            username: "",
+            password: None,
+            host: Some(
+                Domain(
+                    "www.youtube.com",
+                ),
+            ),
+            port: None,
+            path: "/",
+            query: None,
+            fragment: None,
+        },
+        chars: Url {
+            scheme: "https",
+            cannot_be_a_base: false,
+            username: "",
+            password: None,
+            host: Some(
+                Domain(
+                    "www.youtube.com",
+                ),
+            ),
+            port: None,
+            path: "/",
+            query: None,
+            fragment: None,
+        },
+        graphemes: Url {
+            scheme: "https",
+            cannot_be_a_base: false,
+            username: "",
+            password: None,
+            host: Some(
+                Domain(
+                    "www.youtube.com",
+                ),
+            ),
+            port: None,
+            path: "/",
+            query: None,
+            fragment: None,
+        },
+        utf_16_code_units: Url {
+            scheme: "https",
+            cannot_be_a_base: false,
+            username: "",
+            password: None,
+            host: Some(
+                Domain(
+                    "www.youtube.com",
+                ),
+            ),
+            port: None,
+            path: "/",
+            query: None,
+            fragment: None,
+        },
+    },
+}
+field: length is lower than 30
+v.bytes: length is lower than 30
+v.chars: length is lower than 30
+v.default: length is lower than 30
+v.graphemes: length is lower than 30
+v.simple: length is lower than 30
+v.utf_16_code_units: length is lower than 30
+
+Tuple(
+    Url {
+        scheme: "https",
+        cannot_be_a_base: false,
+        username: "",
+        password: None,
+        host: Some(
+            Domain(
+                "www.youtube.com",
+            ),
+        ),
+        port: None,
+        path: "/",
+        query: None,
+        fragment: None,
+    },
+)
+[0]: length is lower than 30

--- a/garde/tests/rules/snapshots/rules__rules__url__length__url_invalid.snap
+++ b/garde/tests/rules/snapshots/rules__rules__url__length__url_invalid.snap
@@ -1,0 +1,102 @@
+---
+source: garde/tests/./rules/url.rs
+expression: snapshot
+---
+Struct {
+    default: Url {
+        scheme: "https",
+        cannot_be_a_base: false,
+        username: "",
+        password: None,
+        host: Some(
+            Domain(
+                "www.youtube.com",
+            ),
+        ),
+        port: None,
+        path: "/",
+        query: None,
+        fragment: None,
+    },
+    simple: Url {
+        scheme: "https",
+        cannot_be_a_base: false,
+        username: "",
+        password: None,
+        host: Some(
+            Domain(
+                "www.youtube.com",
+            ),
+        ),
+        port: None,
+        path: "/",
+        query: None,
+        fragment: None,
+    },
+    bytes: Url {
+        scheme: "https",
+        cannot_be_a_base: false,
+        username: "",
+        password: None,
+        host: Some(
+            Domain(
+                "www.youtube.com",
+            ),
+        ),
+        port: None,
+        path: "/",
+        query: None,
+        fragment: None,
+    },
+    chars: Url {
+        scheme: "https",
+        cannot_be_a_base: false,
+        username: "",
+        password: None,
+        host: Some(
+            Domain(
+                "www.youtube.com",
+            ),
+        ),
+        port: None,
+        path: "/",
+        query: None,
+        fragment: None,
+    },
+    graphemes: Url {
+        scheme: "https",
+        cannot_be_a_base: false,
+        username: "",
+        password: None,
+        host: Some(
+            Domain(
+                "www.youtube.com",
+            ),
+        ),
+        port: None,
+        path: "/",
+        query: None,
+        fragment: None,
+    },
+    utf_16_code_units: Url {
+        scheme: "https",
+        cannot_be_a_base: false,
+        username: "",
+        password: None,
+        host: Some(
+            Domain(
+                "www.youtube.com",
+            ),
+        ),
+        port: None,
+        path: "/",
+        query: None,
+        fragment: None,
+    },
+}
+bytes: length is lower than 30
+chars: length is lower than 30
+default: length is lower than 30
+graphemes: length is lower than 30
+simple: length is lower than 30
+utf_16_code_units: length is lower than 30

--- a/garde/tests/rules/snapshots/rules__rules__url__length__url_invalid_long.snap
+++ b/garde/tests/rules/snapshots/rules__rules__url__length__url_invalid_long.snap
@@ -1,0 +1,114 @@
+---
+source: garde/tests/./rules/url.rs
+expression: snapshot
+---
+Struct {
+    default: Url {
+        scheme: "https",
+        cannot_be_a_base: false,
+        username: "",
+        password: None,
+        host: Some(
+            Domain(
+                "www.youtube.com",
+            ),
+        ),
+        port: None,
+        path: "/watch",
+        query: Some(
+            "v=dQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQ",
+        ),
+        fragment: None,
+    },
+    simple: Url {
+        scheme: "https",
+        cannot_be_a_base: false,
+        username: "",
+        password: None,
+        host: Some(
+            Domain(
+                "www.youtube.com",
+            ),
+        ),
+        port: None,
+        path: "/watch",
+        query: Some(
+            "v=dQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQ",
+        ),
+        fragment: None,
+    },
+    bytes: Url {
+        scheme: "https",
+        cannot_be_a_base: false,
+        username: "",
+        password: None,
+        host: Some(
+            Domain(
+                "www.youtube.com",
+            ),
+        ),
+        port: None,
+        path: "/watch",
+        query: Some(
+            "v=dQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQ",
+        ),
+        fragment: None,
+    },
+    chars: Url {
+        scheme: "https",
+        cannot_be_a_base: false,
+        username: "",
+        password: None,
+        host: Some(
+            Domain(
+                "www.youtube.com",
+            ),
+        ),
+        port: None,
+        path: "/watch",
+        query: Some(
+            "v=dQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQ",
+        ),
+        fragment: None,
+    },
+    graphemes: Url {
+        scheme: "https",
+        cannot_be_a_base: false,
+        username: "",
+        password: None,
+        host: Some(
+            Domain(
+                "www.youtube.com",
+            ),
+        ),
+        port: None,
+        path: "/watch",
+        query: Some(
+            "v=dQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQ",
+        ),
+        fragment: None,
+    },
+    utf_16_code_units: Url {
+        scheme: "https",
+        cannot_be_a_base: false,
+        username: "",
+        password: None,
+        host: Some(
+            Domain(
+                "www.youtube.com",
+            ),
+        ),
+        port: None,
+        path: "/watch",
+        query: Some(
+            "v=dQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQ",
+        ),
+        fragment: None,
+    },
+}
+bytes: length is greater than 100
+chars: length is greater than 100
+default: length is greater than 100
+graphemes: length is greater than 100
+simple: length is greater than 100
+utf_16_code_units: length is greater than 100

--- a/garde/tests/rules/snapshots/rules__rules__url__length__url_invalid_short.snap
+++ b/garde/tests/rules/snapshots/rules__rules__url__length__url_invalid_short.snap
@@ -1,0 +1,102 @@
+---
+source: garde/tests/./rules/url.rs
+expression: snapshot
+---
+Struct {
+    default: Url {
+        scheme: "https",
+        cannot_be_a_base: false,
+        username: "",
+        password: None,
+        host: Some(
+            Domain(
+                "www.youtube.com",
+            ),
+        ),
+        port: None,
+        path: "/",
+        query: None,
+        fragment: None,
+    },
+    simple: Url {
+        scheme: "https",
+        cannot_be_a_base: false,
+        username: "",
+        password: None,
+        host: Some(
+            Domain(
+                "www.youtube.com",
+            ),
+        ),
+        port: None,
+        path: "/",
+        query: None,
+        fragment: None,
+    },
+    bytes: Url {
+        scheme: "https",
+        cannot_be_a_base: false,
+        username: "",
+        password: None,
+        host: Some(
+            Domain(
+                "www.youtube.com",
+            ),
+        ),
+        port: None,
+        path: "/",
+        query: None,
+        fragment: None,
+    },
+    chars: Url {
+        scheme: "https",
+        cannot_be_a_base: false,
+        username: "",
+        password: None,
+        host: Some(
+            Domain(
+                "www.youtube.com",
+            ),
+        ),
+        port: None,
+        path: "/",
+        query: None,
+        fragment: None,
+    },
+    graphemes: Url {
+        scheme: "https",
+        cannot_be_a_base: false,
+        username: "",
+        password: None,
+        host: Some(
+            Domain(
+                "www.youtube.com",
+            ),
+        ),
+        port: None,
+        path: "/",
+        query: None,
+        fragment: None,
+    },
+    utf_16_code_units: Url {
+        scheme: "https",
+        cannot_be_a_base: false,
+        username: "",
+        password: None,
+        host: Some(
+            Domain(
+                "www.youtube.com",
+            ),
+        ),
+        port: None,
+        path: "/",
+        query: None,
+        fragment: None,
+    },
+}
+bytes: length is lower than 30
+chars: length is lower than 30
+default: length is lower than 30
+graphemes: length is lower than 30
+simple: length is lower than 30
+utf_16_code_units: length is lower than 30

--- a/garde/tests/rules/snapshots/rules__rules__url__length__url_tuple_invalid.snap
+++ b/garde/tests/rules/snapshots/rules__rules__url__length__url_tuple_invalid.snap
@@ -1,0 +1,22 @@
+---
+source: garde/tests/./rules/url.rs
+expression: snapshot
+---
+Tuple(
+    Url {
+        scheme: "https",
+        cannot_be_a_base: false,
+        username: "",
+        password: None,
+        host: Some(
+            Domain(
+                "youtube.com",
+            ),
+        ),
+        port: None,
+        path: "/",
+        query: None,
+        fragment: None,
+    },
+)
+[0]: length is lower than 30

--- a/garde/tests/rules/url.rs
+++ b/garde/tests/rules/url.rs
@@ -1,4 +1,5 @@
 use garde::Validate;
+use url::Url;
 
 use super::util;
 
@@ -108,4 +109,170 @@ fn url_valid_wrapper() {
         inner: &["htt ps://www.youtube.com/watch?v=dQw4w9WgXcQ"],
     };
     println!("{:?}", value.validate().unwrap_err());
+}
+
+mod length {
+    use super::*;
+
+    #[derive(Debug, Validate)]
+    struct Struct {
+        #[garde(length(min = 30, max = 100))]
+        default: Url,
+        #[garde(length(simple, min = 30, max = 100))]
+        simple: Url,
+        #[garde(length(bytes, min = 30, max = 100))]
+        bytes: Url,
+        #[garde(length(chars, min = 30, max = 100))]
+        chars: Url,
+        #[garde(length(graphemes, min = 30, max = 100))]
+        graphemes: Url,
+        #[garde(length(utf16, min = 30, max = 100))]
+        utf_16_code_units: Url,
+    }
+
+    #[derive(Debug, Validate)]
+    struct Tuple(#[garde(length(min = 30, max = 100))] Url);
+
+    #[derive(Debug, Validate)]
+    #[allow(clippy::large_enum_variant)]
+    enum Enum {
+        Unit,
+        Struct {
+            #[garde(length(min = 30, max = 100))]
+            field: Url,
+            #[garde(dive)]
+            v: Struct,
+        },
+        Tuple(#[garde(length(min = 30, max = 100))] Url),
+    }
+
+    #[test]
+    fn url_valid() {
+        let url: Url = "http://info.cern.ch/hypertext/WWW/TheProject.html"
+            .parse()
+            .unwrap();
+
+        util::check_ok(
+            &[Struct {
+                default: url.clone(),
+                simple: url.clone(),
+                bytes: url.clone(),
+                chars: url.clone(),
+                graphemes: url.clone(),
+                utf_16_code_units: url.clone(),
+            }],
+            &(),
+        )
+    }
+
+    #[test]
+    fn url_tuple_valid() {
+        util::check_ok(
+            &[Tuple(
+                "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+                    .parse()
+                    .unwrap(),
+            )],
+            &(),
+        )
+    }
+
+    #[test]
+    fn url_enum_valid() {
+        let url: Url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+            .parse()
+            .unwrap();
+        util::check_ok(
+            &[
+                Enum::Unit,
+                Enum::Struct {
+                    field: url.clone(),
+                    v: Struct {
+                        default: url.clone(),
+                        simple: url.clone(),
+                        bytes: url.clone(),
+                        chars: url.clone(),
+                        graphemes: url.clone(),
+                        utf_16_code_units: url.clone(),
+                    },
+                },
+                Enum::Tuple(url.clone()),
+            ],
+            &(),
+        )
+    }
+
+    #[test]
+    fn url_invalid_short() {
+        let short_url: Url = "https://www.youtube.com".parse().unwrap();
+        util::check_fail!(
+            &[Struct {
+                default: short_url.clone(),
+                simple: short_url.clone(),
+                bytes: short_url.clone(),
+                chars: short_url.clone(),
+                graphemes: short_url.clone(),
+                utf_16_code_units: short_url.clone(),
+            }],
+            &()
+        );
+    }
+
+    #[test]
+    fn url_invalid_long() {
+        let long_url: Url = "https://www.youtube.com/watch?v=dQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQdQw4w9WgXcQ".parse().unwrap();
+        util::check_fail!(
+            &[Struct {
+                default: long_url.clone(),
+                simple: long_url.clone(),
+                bytes: long_url.clone(),
+                chars: long_url.clone(),
+                graphemes: long_url.clone(),
+                utf_16_code_units: long_url.clone(),
+            }],
+            &()
+        );
+    }
+
+    #[test]
+    fn url_tuple_invalid() {
+        util::check_fail!(&[Tuple("https://youtube.com".parse().unwrap())], &())
+    }
+
+    #[test]
+    fn url_enum_invalid() {
+        let url: Url = "https://www.youtube.com".parse().unwrap();
+
+        util::check_fail!(
+            &[
+                Enum::Struct {
+                    field: url.clone(),
+                    v: Struct {
+                        default: url.clone(),
+                        simple: url.clone(),
+                        bytes: url.clone(),
+                        chars: url.clone(),
+                        graphemes: url.clone(),
+                        utf_16_code_units: url.clone(),
+                    },
+                },
+                Enum::Tuple(url.clone()),
+            ],
+            &(),
+        )
+    }
+
+    #[test]
+    fn url_valid_wrapper() {
+        let url: Url = "https://www.youtube.com".parse().unwrap();
+        let value = Struct {
+            default: url.clone(),
+            simple: url.clone(),
+            bytes: url.clone(),
+            chars: url.clone(),
+            graphemes: url.clone(),
+            utf_16_code_units: url.clone(),
+        };
+        println!("{:?}", value.validate().unwrap_err());
+    }
 }


### PR DESCRIPTION
I'm using `Url` structs directly in my forms to make working with them more convenient. With this patch, garde can validate the length of these structs.

Notes:
- I copied and adapted most of the existing url tests to check the new length functionality; I'm not sure if it's really necessary to test the new stuff using enums, tuples etc.
- I didn't try it, but it would be super cool to implement length rules for types that implement `AsStr`, e.g. `impl HasSimpleLength for <T: AsStr>`. Then we could just `impl AsStr for Url` and unlock more rules for `Url` structs. Even if it's not feasible for length rules, implementing `AsStr` for `Url` might be a good addition in a second PR.
- I put the new rule implementations into the `rules/url` module rather than the individual `rules/length` modules, as I think it's worthwile to have all functionality gated behind the `url` feature in one place. If you think it's better the other way around I'll change it.

I'm happy to change the approach if you think it makes more sense in another way!