### PR TITLE
feat: Add conditional validation with `if(cond = <expr>, <rules>...)` syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,10 @@ Additional notes:
 - For `contains`, `prefix`, and `suffix`, the pattern must be a string literal, because the `Pattern` API [is currently unstable](https://github.com/rust-lang/rust/issues/27721).
 - For `if` conditional validation:
   - The condition expression can access `self` fields and context variables (e.g., `ctx`).
-  - Multiple rules can be specified after the condition: `if(cond = expr, rule1, rule2, ...)`.
+  - Multiple rules can be specified with the condition: `if(cond = expr, rule1, rule2, ...)`.
+  - The `cond = expr` argument may appear anywhere in the rule.
   - Multiple conditional blocks can be used on the same field.
-  - Conditional validation cannot be used inside `inner` rules.
+  - Conditional validation can be nested with `inner`.
 - Garde does not enable the default features of the `regex` crate - if you need extra regex features (e.g. Unicode) or better performance, add a dependency on `regex = "1"` to your `Cargo.toml`.
 
 If most of the fields on your struct are annotated with `#[garde(skip)]`, you may use `#[garde(allow_unvalidated)]` instead:
@@ -400,7 +401,7 @@ struct User {
 }
 ```
 
-You can use multiple rules within a single condition:
+You can use multiple rules within a single condition. `cond = ...` may appear anywhere:
 
 ```rust
 #[derive(garde::Validate)]
@@ -408,7 +409,7 @@ struct Account {
     #[garde(skip)]
     strict_mode: bool,
     
-    #[garde(if(cond = self.strict_mode, ascii, length(min = 12), alphanumeric))]
+    #[garde(if(ascii, cond = self.strict_mode, length(min = 12), alphanumeric))]
     password: String,
 }
 ```
@@ -447,6 +448,19 @@ struct ApiKey {
 
 struct Config {
     production: bool,
+}
+```
+
+Conditional validation can be nested with `inner`:
+
+```rust
+#[derive(garde::Validate)]
+struct Items {
+    #[garde(skip)]
+    check_items: bool,
+
+    #[garde(inner(if(cond = self.check_items, ascii)))]
+    items: Vec<String>,
 }
 ```
 

--- a/garde/examples/test_if.rs
+++ b/garde/examples/test_if.rs
@@ -13,34 +13,34 @@ fn main() {
         should_validate: true,
         value: "hello".to_string(),
     };
-    
+
     let test2 = Test {
         should_validate: false,
         value: "こんにちは".to_string(),
     };
-    
+
     println!("Testing conditional validation...");
-    
+
     match test1.validate() {
         Ok(_) => println!("✓ Test 1 passed: ASCII validation applied when condition is true"),
         Err(e) => println!("✗ Test 1 failed: {}", e),
     }
-    
+
     match test2.validate() {
         Ok(_) => println!("✓ Test 2 passed: Non-ASCII allowed when condition is false"),
         Err(e) => println!("✗ Test 2 failed: {}", e),
     }
-    
+
     // Test failure case
     let test3 = Test {
         should_validate: true,
         value: "こんにちは".to_string(),
     };
-    
+
     match test3.validate() {
         Ok(_) => println!("✗ Test 3 should have failed"),
         Err(e) => println!("✓ Test 3 correctly failed: {}", e),
     }
-    
+
     println!("Conditional validation test complete!");
 }

--- a/garde/examples/test_if.rs
+++ b/garde/examples/test_if.rs
@@ -1,0 +1,46 @@
+use garde::Validate;
+
+#[derive(Debug, Validate)]
+struct Test {
+    #[garde(skip)]
+    should_validate: bool,
+    #[garde(if(cond = self.should_validate, ascii))]
+    value: String,
+}
+
+fn main() {
+    let test1 = Test {
+        should_validate: true,
+        value: "hello".to_string(),
+    };
+    
+    let test2 = Test {
+        should_validate: false,
+        value: "こんにちは".to_string(),
+    };
+    
+    println!("Testing conditional validation...");
+    
+    match test1.validate() {
+        Ok(_) => println!("✓ Test 1 passed: ASCII validation applied when condition is true"),
+        Err(e) => println!("✗ Test 1 failed: {}", e),
+    }
+    
+    match test2.validate() {
+        Ok(_) => println!("✓ Test 2 passed: Non-ASCII allowed when condition is false"),
+        Err(e) => println!("✗ Test 2 failed: {}", e),
+    }
+    
+    // Test failure case
+    let test3 = Test {
+        should_validate: true,
+        value: "こんにちは".to_string(),
+    };
+    
+    match test3.validate() {
+        Ok(_) => println!("✗ Test 3 should have failed"),
+        Err(e) => println!("✓ Test 3 correctly failed: {}", e),
+    }
+    
+    println!("Conditional validation test complete!");
+}

--- a/garde/examples/test_if_complex.rs
+++ b/garde/examples/test_if_complex.rs
@@ -5,19 +5,19 @@ use garde::Validate;
 struct User {
     #[garde(skip)]
     is_admin: bool,
-    
+
     #[garde(skip)]
     validate_email: bool,
-    
+
     #[garde(if(cond = self.is_admin && ctx.strict_mode, length(min = 8)))]
     username: String,
-    
+
     #[garde(
         if(cond = self.validate_email, ascii),
         required
     )]
     email: Option<String>,
-    
+
     #[garde(
         if(cond = ctx.strict_mode, length(min = 16)),
         if(cond = !ctx.strict_mode, length(min = 4))
@@ -31,10 +31,10 @@ struct Config {
 
 fn main() {
     println!("Testing complex conditional validation...\n");
-    
+
     // Test with strict mode enabled
     let strict_ctx = Config { strict_mode: true };
-    
+
     let user1 = User {
         is_admin: true,
         validate_email: true,
@@ -42,19 +42,15 @@ fn main() {
         email: Some("admin@example.com".to_string()),
         password: "verylongpassword123".to_string(),
     };
-    
+
     let mut report = garde::error::Report::new();
-    user1.validate_into(
-        &strict_ctx,
-        &mut || garde::Path::new("user1"),
-        &mut report,
-    );
+    user1.validate_into(&strict_ctx, &mut || garde::Path::new("user1"), &mut report);
     if report.is_empty() {
         println!("✓ Strict admin user passed validation");
     } else {
         println!("✗ Strict admin user failed: {}", report);
     }
-    
+
     // Test with non-admin user in strict mode
     let user2 = User {
         is_admin: false,
@@ -63,22 +59,18 @@ fn main() {
         email: Some("user@example.com".to_string()), // Should be OK since validate_email is false
         password: "verylongpassword123".to_string(),
     };
-    
+
     let mut report = garde::error::Report::new();
-    user2.validate_into(
-        &strict_ctx,
-        &mut || garde::Path::new("user2"),
-        &mut report,
-    );
+    user2.validate_into(&strict_ctx, &mut || garde::Path::new("user2"), &mut report);
     if report.is_empty() {
         println!("✓ Non-admin user in strict mode passed");
     } else {
         println!("✗ Non-admin user in strict mode failed: {}", report);
     }
-    
+
     // Test with non-strict mode
     let lenient_ctx = Config { strict_mode: false };
-    
+
     let user3 = User {
         is_admin: true,
         validate_email: true,
@@ -86,19 +78,15 @@ fn main() {
         email: Some("user@example.com".to_string()),
         password: "pass".to_string(), // Only needs 4+ chars in non-strict mode
     };
-    
+
     let mut report = garde::error::Report::new();
-    user3.validate_into(
-        &lenient_ctx,
-        &mut || garde::Path::new("user3"),
-        &mut report,
-    );
+    user3.validate_into(&lenient_ctx, &mut || garde::Path::new("user3"), &mut report);
     if report.is_empty() {
         println!("✓ User in lenient mode passed");
     } else {
         println!("✗ User in lenient mode failed: {}", report);
     }
-    
+
     // Test failure case - admin in strict mode with short username
     let user4 = User {
         is_admin: true,
@@ -107,18 +95,14 @@ fn main() {
         email: None,
         password: "verylongpassword123".to_string(),
     };
-    
+
     let mut report = garde::error::Report::new();
-    user4.validate_into(
-        &strict_ctx,
-        &mut || garde::Path::new("user4"),
-        &mut report,
-    );
+    user4.validate_into(&strict_ctx, &mut || garde::Path::new("user4"), &mut report);
     if report.is_empty() {
         println!("✗ Should have failed validation");
     } else {
         println!("✓ Correctly failed admin with short username: {}", report);
     }
-    
+
     println!("\nConditional validation test complete!");
 }

--- a/garde/examples/test_if_complex.rs
+++ b/garde/examples/test_if_complex.rs
@@ -1,0 +1,124 @@
+use garde::Validate;
+
+#[derive(Debug, Validate)]
+#[garde(context(Config as ctx))]
+struct User {
+    #[garde(skip)]
+    is_admin: bool,
+    
+    #[garde(skip)]
+    validate_email: bool,
+    
+    #[garde(if(cond = self.is_admin && ctx.strict_mode, length(min = 8)))]
+    username: String,
+    
+    #[garde(
+        if(cond = self.validate_email, ascii),
+        required
+    )]
+    email: Option<String>,
+    
+    #[garde(
+        if(cond = ctx.strict_mode, length(min = 16)),
+        if(cond = !ctx.strict_mode, length(min = 4))
+    )]
+    password: String,
+}
+
+struct Config {
+    strict_mode: bool,
+}
+
+fn main() {
+    println!("Testing complex conditional validation...\n");
+    
+    // Test with strict mode enabled
+    let strict_ctx = Config { strict_mode: true };
+    
+    let user1 = User {
+        is_admin: true,
+        validate_email: true,
+        username: "administrator".to_string(),
+        email: Some("admin@example.com".to_string()),
+        password: "verylongpassword123".to_string(),
+    };
+    
+    let mut report = garde::error::Report::new();
+    user1.validate_into(
+        &strict_ctx,
+        &mut || garde::Path::new("user1"),
+        &mut report,
+    );
+    if report.is_empty() {
+        println!("✓ Strict admin user passed validation");
+    } else {
+        println!("✗ Strict admin user failed: {}", report);
+    }
+    
+    // Test with non-admin user in strict mode
+    let user2 = User {
+        is_admin: false,
+        validate_email: false,
+        username: "short".to_string(), // Should be OK since is_admin is false
+        email: Some("user@example.com".to_string()), // Should be OK since validate_email is false
+        password: "verylongpassword123".to_string(),
+    };
+    
+    let mut report = garde::error::Report::new();
+    user2.validate_into(
+        &strict_ctx,
+        &mut || garde::Path::new("user2"),
+        &mut report,
+    );
+    if report.is_empty() {
+        println!("✓ Non-admin user in strict mode passed");
+    } else {
+        println!("✗ Non-admin user in strict mode failed: {}", report);
+    }
+    
+    // Test with non-strict mode
+    let lenient_ctx = Config { strict_mode: false };
+    
+    let user3 = User {
+        is_admin: true,
+        validate_email: true,
+        username: "short".to_string(), // Should be OK since strict_mode is false
+        email: Some("user@example.com".to_string()),
+        password: "pass".to_string(), // Only needs 4+ chars in non-strict mode
+    };
+    
+    let mut report = garde::error::Report::new();
+    user3.validate_into(
+        &lenient_ctx,
+        &mut || garde::Path::new("user3"),
+        &mut report,
+    );
+    if report.is_empty() {
+        println!("✓ User in lenient mode passed");
+    } else {
+        println!("✗ User in lenient mode failed: {}", report);
+    }
+    
+    // Test failure case - admin in strict mode with short username
+    let user4 = User {
+        is_admin: true,
+        validate_email: false,
+        username: "short".to_string(), // Should fail - admin + strict mode requires 8+ chars
+        email: None,
+        password: "verylongpassword123".to_string(),
+    };
+    
+    let mut report = garde::error::Report::new();
+    user4.validate_into(
+        &strict_ctx,
+        &mut || garde::Path::new("user4"),
+        &mut report,
+    );
+    if report.is_empty() {
+        println!("✗ Should have failed validation");
+    } else {
+        println!("✓ Correctly failed admin with short username: {}", report);
+    }
+    
+    println!("\nConditional validation test complete!");
+}

--- a/garde/tests/rules/if_conditional.rs
+++ b/garde/tests/rules/if_conditional.rs
@@ -47,10 +47,10 @@ fn simple_conditional_invalid_when_true() {
 struct WithContext {
     #[garde(if(cond = ctx.strict_mode, length(min = 8), alphanumeric))]
     password: String,
-    
+
     #[garde(if(cond = self.email_required, email, required))]
     email: Option<String>,
-    
+
     #[garde(skip)]
     email_required: bool,
 }
@@ -104,7 +104,7 @@ struct MultipleConditions {
     check_format: bool,
     #[garde(skip)]
     check_length: bool,
-    
+
     #[garde(
         if(cond = self.check_format, ascii),
         if(cond = self.check_length, length(min = 5, max = 20)),
@@ -157,7 +157,7 @@ struct ComplexCondition {
     is_admin: bool,
     #[garde(skip)]
     is_active: bool,
-    
+
     #[garde(if(cond = self.is_admin && self.is_active, length(min = 16)))]
     api_key: String,
 }

--- a/garde/tests/rules/if_conditional.rs
+++ b/garde/tests/rules/if_conditional.rs
@@ -1,0 +1,188 @@
+use super::util;
+
+#[derive(Debug, garde::Validate)]
+struct SimpleConditional {
+    #[garde(skip)]
+    validate_username: bool,
+    #[garde(if(cond = self.validate_username, ascii, length(min = 3)))]
+    username: String,
+}
+
+#[test]
+fn simple_conditional_valid_when_true() {
+    util::check_ok(
+        &[SimpleConditional {
+            validate_username: true,
+            username: "test".to_string(),
+        }],
+        &(),
+    )
+}
+
+#[test]
+fn simple_conditional_valid_when_false() {
+    // Should pass validation even with non-ASCII when condition is false
+    util::check_ok(
+        &[SimpleConditional {
+            validate_username: false,
+            username: "テスト".to_string(),
+        }],
+        &(),
+    )
+}
+
+#[test]
+fn simple_conditional_invalid_when_true() {
+    util::check_fail!(
+        &[SimpleConditional {
+            validate_username: true,
+            username: "テスト".to_string(),
+        }],
+        &()
+    )
+}
+
+#[derive(Debug, garde::Validate)]
+#[garde(context(ValidationContext as ctx))]
+struct WithContext {
+    #[garde(if(cond = ctx.strict_mode, length(min = 8), alphanumeric))]
+    password: String,
+    
+    #[garde(if(cond = self.email_required, email, required))]
+    email: Option<String>,
+    
+    #[garde(skip)]
+    email_required: bool,
+}
+
+struct ValidationContext {
+    strict_mode: bool,
+}
+
+#[test]
+fn context_conditional_valid() {
+    let ctx = ValidationContext { strict_mode: true };
+    util::check_ok(
+        &[WithContext {
+            password: "SecurePass123".to_string(),
+            email: Some("test@example.com".to_string()),
+            email_required: true,
+        }],
+        &ctx,
+    )
+}
+
+#[test]
+fn context_conditional_invalid() {
+    let ctx = ValidationContext { strict_mode: true };
+    util::check_fail!(
+        &[WithContext {
+            password: "weak".to_string(),
+            email: None,
+            email_required: true,
+        }],
+        &ctx
+    )
+}
+
+#[test]
+fn context_conditional_valid_when_false() {
+    let ctx = ValidationContext { strict_mode: false };
+    util::check_ok(
+        &[WithContext {
+            password: "weak!".to_string(),
+            email: None,
+            email_required: false,
+        }],
+        &ctx,
+    )
+}
+
+#[derive(Debug, garde::Validate)]
+struct MultipleConditions {
+    #[garde(skip)]
+    check_format: bool,
+    #[garde(skip)]
+    check_length: bool,
+    
+    #[garde(
+        if(cond = self.check_format, ascii),
+        if(cond = self.check_length, length(min = 5, max = 20)),
+        required  // Unconditional rule
+    )]
+    value: Option<String>,
+}
+
+#[test]
+fn multiple_conditions_all_true() {
+    util::check_ok(
+        &[MultipleConditions {
+            check_format: true,
+            check_length: true,
+            value: Some("hello".to_string()),
+        }],
+        &(),
+    )
+}
+
+#[test]
+fn multiple_conditions_mixed() {
+    // Format check disabled, length check enabled
+    util::check_ok(
+        &[MultipleConditions {
+            check_format: false,
+            check_length: true,
+            value: Some("こんにちは".to_string()), // Non-ASCII but length is OK
+        }],
+        &(),
+    )
+}
+
+#[test]
+fn multiple_conditions_unconditional_fail() {
+    // Required rule always applies
+    util::check_fail!(
+        &[MultipleConditions {
+            check_format: false,
+            check_length: false,
+            value: None,
+        }],
+        &()
+    )
+}
+
+#[derive(Debug, garde::Validate)]
+struct ComplexCondition {
+    #[garde(skip)]
+    is_admin: bool,
+    #[garde(skip)]
+    is_active: bool,
+    
+    #[garde(if(cond = self.is_admin && self.is_active, length(min = 16)))]
+    api_key: String,
+}
+
+#[test]
+fn complex_condition_valid() {
+    util::check_ok(
+        &[ComplexCondition {
+            is_admin: true,
+            is_active: true,
+            api_key: "a".repeat(16),
+        }],
+        &(),
+    )
+}
+
+#[test]
+fn complex_condition_partial_false() {
+    // Only one condition is true, so validation should not apply
+    util::check_ok(
+        &[ComplexCondition {
+            is_admin: true,
+            is_active: false,
+            api_key: "short".to_string(),
+        }],
+        &(),
+    )
+}

--- a/garde/tests/rules/if_conditional.rs
+++ b/garde/tests/rules/if_conditional.rs
@@ -45,7 +45,7 @@ fn simple_conditional_invalid_when_true() {
 #[derive(Debug, garde::Validate)]
 #[garde(context(ValidationContext as ctx))]
 struct WithContext {
-    #[garde(if(cond = ctx.strict_mode, length(min = 8), alphanumeric))]
+    #[garde(if(length(min = 8), cond = ctx.strict_mode, alphanumeric))]
     password: String,
 
     #[garde(if(cond = self.email_required, email, required))]

--- a/garde/tests/rules/if_conditional.rs
+++ b/garde/tests/rules/if_conditional.rs
@@ -186,3 +186,309 @@ fn complex_condition_partial_false() {
         &(),
     )
 }
+
+#[derive(Debug, garde::Validate)]
+struct ConditionalInner {
+    #[garde(skip)]
+    validate_items: bool,
+
+    #[garde(if(cond = self.validate_items, inner(ascii, length(min = 3))))]
+    items: Vec<String>,
+}
+
+#[test]
+fn conditional_inner_validates_items_when_true() {
+    util::check_fail!(
+        &[ConditionalInner {
+            validate_items: true,
+            items: vec!["okay".to_string(), "é".to_string()],
+        }],
+        &()
+    )
+}
+
+#[test]
+fn conditional_inner_skips_items_when_false() {
+    util::check_ok(
+        &[ConditionalInner {
+            validate_items: false,
+            items: vec!["é".to_string()],
+        }],
+        &(),
+    )
+}
+
+#[derive(Debug, garde::Validate)]
+struct InnerConditional {
+    #[garde(skip)]
+    check_ascii: bool,
+    #[garde(skip)]
+    check_length: bool,
+
+    #[garde(inner(
+        if(cond = self.check_ascii, ascii),
+        if(cond = self.check_length, length(min = 3))
+    ))]
+    items: Vec<String>,
+}
+
+#[test]
+fn inner_conditional_validates_items_when_true() {
+    util::check_fail!(
+        &[InnerConditional {
+            check_ascii: true,
+            check_length: true,
+            items: vec!["é".to_string()],
+        }],
+        &()
+    )
+}
+
+#[test]
+fn inner_conditional_skips_items_when_false() {
+    util::check_ok(
+        &[InnerConditional {
+            check_ascii: false,
+            check_length: false,
+            items: vec!["é".to_string()],
+        }],
+        &(),
+    )
+}
+
+#[derive(Debug, garde::Validate)]
+struct NestedConditionalInner {
+    #[garde(skip)]
+    validate_items: bool,
+    #[garde(skip)]
+    check_ascii: bool,
+
+    #[garde(if(
+        cond = self.validate_items,
+        inner(if(cond = self.check_ascii, ascii))
+    ))]
+    items: Vec<String>,
+}
+
+#[test]
+fn nested_conditional_inner_requires_both_conditions() {
+    util::check_ok(
+        &[NestedConditionalInner {
+            validate_items: true,
+            check_ascii: false,
+            items: vec!["é".to_string()],
+        }],
+        &(),
+    );
+
+    util::check_fail!(
+        &[NestedConditionalInner {
+            validate_items: true,
+            check_ascii: true,
+            items: vec!["é".to_string()],
+        }],
+        &()
+    )
+}
+
+struct NestedContext {
+    validate_items: bool,
+    check_ascii: bool,
+    min_len: usize,
+    require_expected_first: bool,
+}
+
+#[derive(Debug, garde::Validate)]
+#[garde(context(NestedContext as ctx))]
+#[garde(custom(validate_contextual_nested_struct))]
+struct ContextualNestedConditional<'a> {
+    #[garde(if(
+        cond = ctx.validate_items,
+        inner(if(cond = ctx.check_ascii, ascii), length(min = ctx.min_len))
+    ))]
+    items: Vec<&'a str>,
+
+    #[garde(skip)]
+    expected_first: &'a str,
+}
+
+fn validate_contextual_nested_struct(
+    value: &ContextualNestedConditional<'_>,
+    ctx: &NestedContext,
+) -> Result<(), garde::Error> {
+    if ctx.require_expected_first && value.items.first() != Some(&value.expected_first) {
+        return Err(garde::Error::new(
+            "first item does not match expected value",
+        ));
+    }
+    Ok(())
+}
+
+#[test]
+fn contextual_nested_conditional_uses_context_and_struct_level_rules() {
+    let ctx = NestedContext {
+        validate_items: true,
+        check_ascii: true,
+        min_len: 3,
+        require_expected_first: true,
+    };
+
+    util::check_fail!(
+        &[ContextualNestedConditional {
+            items: vec!["é"],
+            expected_first: "expected",
+        }],
+        &ctx
+    )
+}
+
+#[test]
+fn contextual_nested_conditional_skips_contextual_field_rules_when_false() {
+    let ctx = NestedContext {
+        validate_items: false,
+        check_ascii: true,
+        min_len: 3,
+        require_expected_first: false,
+    };
+
+    util::check_ok(
+        &[ContextualNestedConditional {
+            items: vec!["é"],
+            expected_first: "expected",
+        }],
+        &ctx,
+    )
+}
+
+#[derive(Debug, garde::Validate)]
+struct ConditionalRequiredInner {
+    #[garde(skip)]
+    require_items: bool,
+
+    #[garde(if(cond = self.require_items, inner(required)))]
+    conditional_inner: Vec<Option<String>>,
+
+    #[garde(inner(if(cond = self.require_items, required)))]
+    inner_conditional: Vec<Option<String>>,
+}
+
+#[test]
+fn conditional_required_inner_validates_options_when_true() {
+    util::check_fail!(
+        &[ConditionalRequiredInner {
+            require_items: true,
+            conditional_inner: vec![None],
+            inner_conditional: vec![None],
+        }],
+        &()
+    )
+}
+
+#[test]
+fn conditional_required_inner_skips_options_when_false() {
+    util::check_ok(
+        &[ConditionalRequiredInner {
+            require_items: false,
+            conditional_inner: vec![None],
+            inner_conditional: vec![None],
+        }],
+        &(),
+    )
+}
+
+struct CustomContext {
+    strict: bool,
+    needle: String,
+}
+
+#[derive(Debug, garde::Validate)]
+#[garde(context(CustomContext as ctx))]
+struct ConditionalCustomInner<'a> {
+    #[garde(inner(if(cond = ctx.strict, custom(matches_needle))))]
+    items: Vec<&'a str>,
+}
+
+fn matches_needle(value: &str, ctx: &CustomContext) -> Result<(), garde::Error> {
+    if value != ctx.needle {
+        return Err(garde::Error::new(format!("not equal to {}", ctx.needle)));
+    }
+    Ok(())
+}
+
+#[test]
+fn conditional_custom_inner_receives_context() {
+    let ctx = CustomContext {
+        strict: true,
+        needle: "needle".to_string(),
+    };
+
+    util::check_fail!(
+        &[ConditionalCustomInner {
+            items: vec!["other"],
+        }],
+        &ctx
+    )
+}
+
+#[derive(Debug, garde::Validate)]
+struct ConditionalAdditionalInner {
+    #[garde(skip)]
+    strict: bool,
+
+    #[garde(inner(ascii), if(cond = self.strict, inner(length(min = 3))))]
+    items: Vec<String>,
+}
+
+#[test]
+fn conditional_additional_inner_rules_are_combined() {
+    util::check_fail!(
+        &[ConditionalAdditionalInner {
+            strict: true,
+            items: vec!["é".to_string()],
+        }],
+        &()
+    )
+}
+
+#[test]
+fn conditional_additional_inner_skips_extra_rules_when_false() {
+    util::check_fail!(
+        &[ConditionalAdditionalInner {
+            strict: false,
+            items: vec!["é".to_string()],
+        }],
+        &()
+    )
+}
+
+#[derive(Debug, garde::Validate)]
+struct DiveChild {
+    #[garde(length(min = 3))]
+    value: String,
+}
+
+#[derive(Debug, garde::Validate)]
+struct DiveWithConditionalSiblingRule {
+    #[garde(skip)]
+    strict: bool,
+
+    #[garde(dive, if(cond = self.strict, custom(always_invalid_child)))]
+    child: DiveChild,
+}
+
+fn always_invalid_child(_: &DiveChild, _: &()) -> Result<(), garde::Error> {
+    Err(garde::Error::new("conditional child rule failed"))
+}
+
+#[test]
+fn dive_can_be_combined_with_conditional_sibling_rules() {
+    util::check_fail!(
+        &[DiveWithConditionalSiblingRule {
+            strict: true,
+            child: DiveChild {
+                value: "x".to_string(),
+            },
+        }],
+        &()
+    )
+}

--- a/garde/tests/rules/mod.rs
+++ b/garde/tests/rules/mod.rs
@@ -9,6 +9,7 @@ mod dive;
 mod dive_with_ctx;
 mod dive_with_rules;
 mod email;
+mod if_conditional;
 mod inner;
 mod ip;
 mod length;

--- a/garde/tests/rules/snapshots/rules__rules__if_conditional__conditional_additional_inner_rules_are_combined.snap
+++ b/garde/tests/rules/snapshots/rules__rules__if_conditional__conditional_additional_inner_rules_are_combined.snap
@@ -1,0 +1,12 @@
+---
+source: garde/tests/./rules/if_conditional.rs
+expression: snapshot
+---
+ConditionalAdditionalInner {
+    strict: true,
+    items: [
+        "é",
+    ],
+}
+items[0]: not ascii
+items[0]: length is lower than 3

--- a/garde/tests/rules/snapshots/rules__rules__if_conditional__conditional_additional_inner_skips_extra_rules_when_false.snap
+++ b/garde/tests/rules/snapshots/rules__rules__if_conditional__conditional_additional_inner_skips_extra_rules_when_false.snap
@@ -1,0 +1,11 @@
+---
+source: garde/tests/./rules/if_conditional.rs
+expression: snapshot
+---
+ConditionalAdditionalInner {
+    strict: false,
+    items: [
+        "é",
+    ],
+}
+items[0]: not ascii

--- a/garde/tests/rules/snapshots/rules__rules__if_conditional__conditional_custom_inner_receives_context.snap
+++ b/garde/tests/rules/snapshots/rules__rules__if_conditional__conditional_custom_inner_receives_context.snap
@@ -1,0 +1,10 @@
+---
+source: garde/tests/./rules/if_conditional.rs
+expression: snapshot
+---
+ConditionalCustomInner {
+    items: [
+        "other",
+    ],
+}
+items[0]: not equal to needle

--- a/garde/tests/rules/snapshots/rules__rules__if_conditional__conditional_inner_validates_items_when_true.snap
+++ b/garde/tests/rules/snapshots/rules__rules__if_conditional__conditional_inner_validates_items_when_true.snap
@@ -1,0 +1,13 @@
+---
+source: garde/tests/./rules/if_conditional.rs
+expression: snapshot
+---
+ConditionalInner {
+    validate_items: true,
+    items: [
+        "okay",
+        "é",
+    ],
+}
+items[1]: not ascii
+items[1]: length is lower than 3

--- a/garde/tests/rules/snapshots/rules__rules__if_conditional__conditional_required_inner_validates_options_when_true.snap
+++ b/garde/tests/rules/snapshots/rules__rules__if_conditional__conditional_required_inner_validates_options_when_true.snap
@@ -1,0 +1,15 @@
+---
+source: garde/tests/./rules/if_conditional.rs
+expression: snapshot
+---
+ConditionalRequiredInner {
+    require_items: true,
+    conditional_inner: [
+        None,
+    ],
+    inner_conditional: [
+        None,
+    ],
+}
+conditional_inner[0]: not set
+inner_conditional[0]: not set

--- a/garde/tests/rules/snapshots/rules__rules__if_conditional__context_conditional_invalid.snap
+++ b/garde/tests/rules/snapshots/rules__rules__if_conditional__context_conditional_invalid.snap
@@ -1,0 +1,11 @@
+---
+source: garde/tests/./rules/if_conditional.rs
+expression: snapshot
+---
+WithContext {
+    password: "weak",
+    email: None,
+    email_required: true,
+}
+email: not set
+password: length is lower than 8

--- a/garde/tests/rules/snapshots/rules__rules__if_conditional__contextual_nested_conditional_uses_context_and_struct_level_rules.snap
+++ b/garde/tests/rules/snapshots/rules__rules__if_conditional__contextual_nested_conditional_uses_context_and_struct_level_rules.snap
@@ -1,0 +1,13 @@
+---
+source: garde/tests/./rules/if_conditional.rs
+expression: snapshot
+---
+ContextualNestedConditional {
+    items: [
+        "é",
+    ],
+    expected_first: "expected",
+}
+first item does not match expected value
+items[0]: length is lower than 3
+items[0]: not ascii

--- a/garde/tests/rules/snapshots/rules__rules__if_conditional__dive_can_be_combined_with_conditional_sibling_rules.snap
+++ b/garde/tests/rules/snapshots/rules__rules__if_conditional__dive_can_be_combined_with_conditional_sibling_rules.snap
@@ -1,0 +1,12 @@
+---
+source: garde/tests/./rules/if_conditional.rs
+expression: snapshot
+---
+DiveWithConditionalSiblingRule {
+    strict: true,
+    child: DiveChild {
+        value: "x",
+    },
+}
+child.value: length is lower than 3
+child: conditional child rule failed

--- a/garde/tests/rules/snapshots/rules__rules__if_conditional__inner_conditional_validates_items_when_true.snap
+++ b/garde/tests/rules/snapshots/rules__rules__if_conditional__inner_conditional_validates_items_when_true.snap
@@ -1,0 +1,13 @@
+---
+source: garde/tests/./rules/if_conditional.rs
+expression: snapshot
+---
+InnerConditional {
+    check_ascii: true,
+    check_length: true,
+    items: [
+        "é",
+    ],
+}
+items[0]: not ascii
+items[0]: length is lower than 3

--- a/garde/tests/rules/snapshots/rules__rules__if_conditional__multiple_conditions_unconditional_fail.snap
+++ b/garde/tests/rules/snapshots/rules__rules__if_conditional__multiple_conditions_unconditional_fail.snap
@@ -1,0 +1,10 @@
+---
+source: garde/tests/./rules/if_conditional.rs
+expression: snapshot
+---
+MultipleConditions {
+    check_format: false,
+    check_length: false,
+    value: None,
+}
+value: not set

--- a/garde/tests/rules/snapshots/rules__rules__if_conditional__nested_conditional_inner_requires_both_conditions.snap
+++ b/garde/tests/rules/snapshots/rules__rules__if_conditional__nested_conditional_inner_requires_both_conditions.snap
@@ -1,0 +1,12 @@
+---
+source: garde/tests/./rules/if_conditional.rs
+expression: snapshot
+---
+NestedConditionalInner {
+    validate_items: true,
+    check_ascii: true,
+    items: [
+        "é",
+    ],
+}
+items[0]: not ascii

--- a/garde/tests/rules/snapshots/rules__rules__if_conditional__simple_conditional_invalid_when_true.snap
+++ b/garde/tests/rules/snapshots/rules__rules__if_conditional__simple_conditional_invalid_when_true.snap
@@ -1,0 +1,9 @@
+---
+source: garde/tests/./rules/if_conditional.rs
+expression: snapshot
+---
+SimpleConditional {
+    validate_username: true,
+    username: "テスト",
+}
+username: not ascii

--- a/garde/tests/ui/compile-fail/dive_with_conditional_inner.rs
+++ b/garde/tests/ui/compile-fail/dive_with_conditional_inner.rs
@@ -1,0 +1,11 @@
+#![allow(dead_code)]
+
+#[derive(garde::Validate)]
+struct Test<'a> {
+    #[garde(skip)]
+    enabled: bool,
+    #[garde(dive, if(cond = self.enabled, inner(length(min = 1))))]
+    field: &'a [&'a str],
+}
+
+fn main() {}

--- a/garde/tests/ui/compile-fail/dive_with_conditional_inner.stderr
+++ b/garde/tests/ui/compile-fail/dive_with_conditional_inner.stderr
@@ -1,0 +1,5 @@
+error: `dive` may not be combined with `inner`
+ --> tests/ui/compile-fail/dive_with_conditional_inner.rs
+  |
+  |     #[garde(dive, if(cond = self.enabled, inner(length(min = 1))))]
+  |             ^^^^

--- a/garde/tests/ui/compile-fail/if_duplicate_rule.rs
+++ b/garde/tests/ui/compile-fail/if_duplicate_rule.rs
@@ -1,0 +1,11 @@
+#![allow(dead_code)]
+
+#[derive(garde::Validate)]
+struct Test<'a> {
+    #[garde(skip)]
+    enabled: bool,
+    #[garde(if(cond = self.enabled, ascii, ascii))]
+    field: &'a str,
+}
+
+fn main() {}

--- a/garde/tests/ui/compile-fail/if_duplicate_rule.stderr
+++ b/garde/tests/ui/compile-fail/if_duplicate_rule.stderr
@@ -1,0 +1,5 @@
+error: duplicate rule `ascii`
+ --> tests/ui/compile-fail/if_duplicate_rule.rs
+  |
+  |     #[garde(if(cond = self.enabled, ascii, ascii))]
+  |                                            ^^^^^

--- a/garde/tests/ui/compile-fail/if_missing_cond.rs
+++ b/garde/tests/ui/compile-fail/if_missing_cond.rs
@@ -1,0 +1,9 @@
+#![allow(dead_code)]
+
+#[derive(garde::Validate)]
+struct Test<'a> {
+    #[garde(if(ascii, length(min = 1)))]
+    field: &'a str,
+}
+
+fn main() {}

--- a/garde/tests/ui/compile-fail/if_missing_cond.stderr
+++ b/garde/tests/ui/compile-fail/if_missing_cond.stderr
@@ -1,0 +1,5 @@
+error: missing `cond` argument
+ --> tests/ui/compile-fail/if_missing_cond.rs
+  |
+  |     #[garde(if(ascii, length(min = 1)))]
+  |                                      ^

--- a/garde/tests/ui/compile-fail/if_with_dive.rs
+++ b/garde/tests/ui/compile-fail/if_with_dive.rs
@@ -1,0 +1,17 @@
+#![allow(dead_code)]
+
+#[derive(garde::Validate)]
+struct Child {
+    #[garde(ascii)]
+    value: String,
+}
+
+#[derive(garde::Validate)]
+struct Test {
+    #[garde(skip)]
+    enabled: bool,
+    #[garde(if(cond = self.enabled, dive))]
+    child: Child,
+}
+
+fn main() {}

--- a/garde/tests/ui/compile-fail/if_with_dive.stderr
+++ b/garde/tests/ui/compile-fail/if_with_dive.stderr
@@ -1,0 +1,5 @@
+error: rule `dive` may only be used at the field level
+ --> tests/ui/compile-fail/if_with_dive.rs
+  |
+  |     #[garde(if(cond = self.enabled, dive))]
+  |                                     ^^^^

--- a/garde/tests/ui/compile-fail/if_with_field_level_rules.rs
+++ b/garde/tests/ui/compile-fail/if_with_field_level_rules.rs
@@ -1,0 +1,19 @@
+#![allow(dead_code)]
+
+#[derive(garde::Validate)]
+struct Test<'a> {
+    #[garde(skip)]
+    enabled: bool,
+    #[garde(if(cond = self.enabled, skip))]
+    skip: &'a str,
+    #[garde(if(cond = self.enabled, rename("renamed")))]
+    rename: &'a str,
+    #[garde(if(cond = self.enabled, adapt(adapter)))]
+    adapt: &'a str,
+    #[garde(if(cond = self.enabled, code("code")))]
+    code: &'a str,
+}
+
+mod adapter {}
+
+fn main() {}

--- a/garde/tests/ui/compile-fail/if_with_field_level_rules.stderr
+++ b/garde/tests/ui/compile-fail/if_with_field_level_rules.stderr
@@ -1,0 +1,23 @@
+error: rule `adapter` may only be used at the field level
+ --> tests/ui/compile-fail/if_with_field_level_rules.rs
+  |
+  |     #[garde(if(cond = self.enabled, adapt(adapter)))]
+  |                                     ^^^^^
+
+error: rule `code` may only be used at the field level
+ --> tests/ui/compile-fail/if_with_field_level_rules.rs
+  |
+  |     #[garde(if(cond = self.enabled, code("code")))]
+  |                                     ^^^^
+
+error: rule `alias` may only be used at the field level
+ --> tests/ui/compile-fail/if_with_field_level_rules.rs
+  |
+  |     #[garde(if(cond = self.enabled, rename("renamed")))]
+  |                                     ^^^^^^
+
+error: rule `skip` may only be used at the field level
+ --> tests/ui/compile-fail/if_with_field_level_rules.rs
+  |
+  |     #[garde(if(cond = self.enabled, skip))]
+  |                                     ^^^^

--- a/garde/tests/ui/compile-pass/if_conditional.rs
+++ b/garde/tests/ui/compile-pass/if_conditional.rs
@@ -1,0 +1,68 @@
+#[derive(garde::Validate)]
+struct SimpleIf {
+    #[garde(skip)]
+    validate: bool,
+    #[garde(if(cond = self.validate, ascii))]
+    field: String,
+}
+
+#[derive(garde::Validate)]
+struct MultipleRulesInIf {
+    #[garde(skip)]
+    strict: bool,
+    #[garde(if(cond = self.strict, ascii, length(min = 3, max = 20)))]
+    username: String,
+}
+
+#[derive(garde::Validate)]
+#[garde(context(Context as ctx))]
+struct WithContext {
+    #[garde(if(cond = ctx.production, alphanumeric, required))]
+    email: Option<String>,
+}
+
+struct Context {
+    production: bool,
+}
+
+#[derive(garde::Validate)]
+struct MultipleIfRules {
+    #[garde(skip)]
+    check_ascii: bool,
+    #[garde(skip)]
+    check_length: bool,
+    #[garde(
+        if(cond = self.check_ascii, ascii),
+        if(cond = self.check_length, length(min = 5)),
+        required
+    )]
+    value: Option<String>,
+}
+
+#[derive(garde::Validate)]
+struct ComplexCondition {
+    #[garde(skip)]
+    is_admin: bool,
+    #[garde(skip)]
+    is_active: bool,
+    #[garde(if(cond = self.is_admin && self.is_active, length(min = 16)))]
+    api_key: String,
+}
+
+#[derive(garde::Validate)]
+#[garde(context(Ctx as ctx))]
+struct MixedConditions {
+    #[garde(skip)]
+    validate_self: bool,
+    #[garde(
+        if(cond = self.validate_self, ascii),
+        if(cond = ctx.strict_mode, length(min = 8))
+    )]
+    value: String,
+}
+
+struct Ctx {
+    strict_mode: bool,
+}
+
+fn main() {}

--- a/garde/tests/ui/compile-pass/if_conditional.rs
+++ b/garde/tests/ui/compile-pass/if_conditional.rs
@@ -65,4 +65,60 @@ struct Ctx {
     strict_mode: bool,
 }
 
+#[derive(garde::Validate)]
+struct ConditionalInner {
+    #[garde(skip)]
+    validate_items: bool,
+    #[garde(if(cond = self.validate_items, inner(ascii, length(min = 2))))]
+    items: Vec<String>,
+}
+
+#[derive(garde::Validate)]
+struct InnerConditional {
+    #[garde(skip)]
+    check_items: bool,
+    #[garde(inner(if(cond = self.check_items, ascii, length(min = 2))))]
+    items: Vec<String>,
+}
+
+#[derive(garde::Validate)]
+struct NestedConditionalInner {
+    #[garde(skip)]
+    validate_items: bool,
+    #[garde(skip)]
+    check_ascii: bool,
+    #[garde(if(
+        cond = self.validate_items,
+        inner(if(cond = self.check_ascii, ascii))
+    ))]
+    items: Vec<String>,
+}
+
+struct NestedCtx {
+    validate_items: bool,
+    check_ascii: bool,
+    min_len: usize,
+}
+
+#[derive(garde::Validate)]
+#[garde(context(NestedCtx as ctx))]
+#[garde(custom(validate_contextual_nested_struct))]
+struct ContextualNestedConditional<'a> {
+    #[garde(if(
+        cond = ctx.validate_items,
+        inner(if(cond = ctx.check_ascii, ascii), length(min = ctx.min_len))
+    ))]
+    items: Vec<&'a str>,
+}
+
+fn validate_contextual_nested_struct(
+    value: &ContextualNestedConditional<'_>,
+    ctx: &NestedCtx,
+) -> Result<(), garde::Error> {
+    if ctx.validate_items && value.items.is_empty() {
+        return Err(garde::Error::new("items must not be empty"));
+    }
+    Ok(())
+}
+
 fn main() {}

--- a/garde/tests/ui/compile-pass/if_conditional.rs
+++ b/garde/tests/ui/compile-pass/if_conditional.rs
@@ -10,7 +10,7 @@ struct SimpleIf {
 struct MultipleRulesInIf {
     #[garde(skip)]
     strict: bool,
-    #[garde(if(cond = self.strict, ascii, length(min = 3, max = 20)))]
+    #[garde(if(ascii, cond = self.strict, length(min = 3, max = 20)))]
     username: String,
 }
 

--- a/garde_derive/src/check.rs
+++ b/garde_derive/src/check.rs
@@ -250,7 +250,6 @@ fn check_field(field: model::Field, options: &model::Options) -> syn::Result<mod
         code: None,
         dive: None,
         rule_set: model::RuleSet::empty(),
-        conditional_rule_sets: Vec::new(),
     };
 
     if raw_rules.is_empty() {
@@ -282,7 +281,7 @@ fn check_field(field: model::Field, options: &model::Options) -> syn::Result<mod
     }
 
     if let Some((span, _)) = field.dive {
-        if field.rule_set.inner.is_some() {
+        if field.rule_set.has_inner_rules() {
             error.maybe_fold(syn::Error::new(
                 span,
                 "`dive` may not be combined with `inner`",
@@ -304,7 +303,7 @@ fn check_rules(
     let mut error = None;
     let mut rule_set = model::RuleSet::empty();
     for raw_rule in raw_rules {
-        if let Err(e) = check_rule(field, raw_rule, &mut rule_set, false) {
+        if let Err(e) = check_rule(field, raw_rule, &mut rule_set, false, false) {
             error.maybe_fold(e);
         };
     }
@@ -319,13 +318,14 @@ fn check_rule(
     raw_rule: model::RawRule,
     rule_set: &mut model::RuleSet,
     is_inner: bool,
+    is_conditional: bool,
 ) -> syn::Result<()> {
     macro_rules! apply {
         ($name:ident = $value:expr, $span:expr) => {{
-            if is_inner {
+            if is_inner || is_conditional {
                 return Err(syn::Error::new(
                     $span,
-                    concat!("rule `", stringify!($name), "` may not be used in `inner`")
+                    concat!("rule `", stringify!($name), "` may only be used at the field level")
                 ));
             }
             match field.$name {
@@ -391,8 +391,13 @@ fn check_rule(
 
             let mut error = None;
             for raw_rule in v.contents {
-                if let Err(e) = check_rule(field, raw_rule, rule_set.inner.as_mut().unwrap(), true)
-                {
+                if let Err(e) = check_rule(
+                    field,
+                    raw_rule,
+                    rule_set.inner.as_mut().unwrap(),
+                    true,
+                    is_conditional,
+                ) {
                     error.maybe_fold(e);
                 }
             }
@@ -401,19 +406,13 @@ fn check_rule(
             }
         }
         If(if_rule) => {
-            if is_inner {
-                return Err(syn::Error::new(
-                    span,
-                    "rule `if` may not be used in `inner`",
-                ));
-            }
-
-            // Process the if rule as a separate conditional rule set
             let mut conditional_rule_set = model::RuleSet::empty();
             let mut error = None;
 
             for raw_rule in if_rule.rules.contents {
-                if let Err(e) = check_rule(field, raw_rule, &mut conditional_rule_set, false) {
+                if let Err(e) =
+                    check_rule(field, raw_rule, &mut conditional_rule_set, is_inner, true)
+                {
                     error.maybe_fold(e);
                 }
             }
@@ -422,10 +421,12 @@ fn check_rule(
                 return Err(error);
             }
 
-            field.conditional_rule_sets.push(model::ConditionalRuleSet {
-                condition: if_rule.condition,
-                rule_set: conditional_rule_set,
-            });
+            rule_set
+                .conditional_rule_sets
+                .push(model::ConditionalRuleSet {
+                    condition: if_rule.condition,
+                    rule_set: conditional_rule_set,
+                });
         }
     };
 

--- a/garde_derive/src/check.rs
+++ b/garde_derive/src/check.rs
@@ -404,24 +404,24 @@ fn check_rule(
             if is_inner {
                 return Err(syn::Error::new(
                     span,
-                    "rule `if` may not be used in `inner`"
+                    "rule `if` may not be used in `inner`",
                 ));
             }
-            
+
             // Process the if rule as a separate conditional rule set
             let mut conditional_rule_set = model::RuleSet::empty();
             let mut error = None;
-            
+
             for raw_rule in if_rule.rules.contents {
                 if let Err(e) = check_rule(field, raw_rule, &mut conditional_rule_set, false) {
                     error.maybe_fold(e);
                 }
             }
-            
+
             if let Some(error) = error {
                 return Err(error);
             }
-            
+
             field.conditional_rule_sets.push(model::ConditionalRuleSet {
                 condition: if_rule.condition,
                 rule_set: conditional_rule_set,

--- a/garde_derive/src/check.rs
+++ b/garde_derive/src/check.rs
@@ -250,6 +250,7 @@ fn check_field(field: model::Field, options: &model::Options) -> syn::Result<mod
         code: None,
         dive: None,
         rule_set: model::RuleSet::empty(),
+        conditional_rule_sets: Vec::new(),
     };
 
     if raw_rules.is_empty() {
@@ -398,6 +399,33 @@ fn check_rule(
             if let Some(error) = error {
                 return Err(error);
             }
+        }
+        If(if_rule) => {
+            if is_inner {
+                return Err(syn::Error::new(
+                    span,
+                    "rule `if` may not be used in `inner`"
+                ));
+            }
+            
+            // Process the if rule as a separate conditional rule set
+            let mut conditional_rule_set = model::RuleSet::empty();
+            let mut error = None;
+            
+            for raw_rule in if_rule.rules.contents {
+                if let Err(e) = check_rule(field, raw_rule, &mut conditional_rule_set, false) {
+                    error.maybe_fold(e);
+                }
+            }
+            
+            if let Some(error) = error {
+                return Err(error);
+            }
+            
+            field.conditional_rule_sets.push(model::ConditionalRuleSet {
+                condition: if_rule.condition,
+                rule_set: conditional_rule_set,
+            });
         }
     };
 

--- a/garde_derive/src/emit.rs
+++ b/garde_derive/src/emit.rs
@@ -419,21 +419,47 @@ where
                 _ => unreachable!("`dive` and `inner` are mutually exclusive"),
             };
 
+            // Generate conditional rule sets
+            let conditional_rules = field.conditional_rule_sets.iter().map(|cond_rule_set| {
+                let condition = &cond_rule_set.condition;
+                let cond_rules = Rules {
+                    rules_mod,
+                    rule_set: &cond_rule_set.rule_set,
+                };
+                quote! {
+                    if #condition {
+                        #cond_rules
+                    }
+                }
+            });
+
             let value = match (outer, inner) {
                 (Some(outer), Some(inner)) => quote! {
                     let __garde_binding = &*#binding;
                     #inner
                     #outer
+                    #(#conditional_rules)*
                 },
                 (None, Some(inner)) => quote! {
                     let __garde_binding = &*#binding;
                     #inner
+                    #(#conditional_rules)*
                 },
                 (Some(outer), None) => quote! {
                     let __garde_binding = &*#binding;
                     #outer
+                    #(#conditional_rules)*
                 },
-                (None, None) => unreachable!("field should already be skipped"),
+                (None, None) => {
+                    if field.conditional_rule_sets.is_empty() {
+                        unreachable!("field should already be skipped")
+                    } else {
+                        quote! {
+                            let __garde_binding = &*#binding;
+                            #(#conditional_rules)*
+                        }
+                    }
+                },
             };
 
             let add = &self.1;

--- a/garde_derive/src/emit.rs
+++ b/garde_derive/src/emit.rs
@@ -178,14 +178,14 @@ impl ToTokens for Tuple<'_> {
     }
 }
 
-struct Inner<'a> {
+struct RuleSet<'a> {
     rules_mod: &'a TokenStream2,
     rule_set: &'a model::RuleSet,
 }
 
-impl ToTokens for Inner<'_> {
+impl ToTokens for RuleSet<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream2) {
-        let Inner {
+        let RuleSet {
             rules_mod,
             rule_set,
         } = self;
@@ -205,7 +205,7 @@ impl ToTokens for Inner<'_> {
             rule_set,
         });
 
-        let value = match (outer, inner) {
+        match (outer, inner) {
             (Some(outer), Some(inner)) => quote! {
                 #outer
                 #inner
@@ -215,6 +215,25 @@ impl ToTokens for Inner<'_> {
             },
             (Some(outer), None) => outer,
             (None, None) => return,
+        }
+        .to_tokens(tokens)
+    }
+}
+
+struct Inner<'a> {
+    rules_mod: &'a TokenStream2,
+    rule_set: &'a model::RuleSet,
+}
+
+impl ToTokens for Inner<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream2) {
+        let Inner {
+            rules_mod,
+            rule_set,
+        } = self;
+        let value = RuleSet {
+            rules_mod,
+            rule_set,
         };
 
         quote! {
@@ -349,6 +368,20 @@ impl ToTokens for Rules<'_> {
             }
             .to_tokens(tokens)
         }
+
+        for cond_rule_set in &rule_set.conditional_rule_sets {
+            let condition = &cond_rule_set.condition;
+            let cond_rules = RuleSet {
+                rules_mod,
+                rule_set: &cond_rule_set.rule_set,
+            };
+            quote! {
+                if #condition {
+                    #cond_rules
+                }
+            }
+            .to_tokens(tokens);
+        }
     }
 }
 
@@ -419,47 +452,21 @@ where
                 _ => unreachable!("`dive` and `inner` are mutually exclusive"),
             };
 
-            // Generate conditional rule sets
-            let conditional_rules = field.conditional_rule_sets.iter().map(|cond_rule_set| {
-                let condition = &cond_rule_set.condition;
-                let cond_rules = Rules {
-                    rules_mod,
-                    rule_set: &cond_rule_set.rule_set,
-                };
-                quote! {
-                    if #condition {
-                        #cond_rules
-                    }
-                }
-            });
-
             let value = match (outer, inner) {
                 (Some(outer), Some(inner)) => quote! {
                     let __garde_binding = &*#binding;
                     #inner
                     #outer
-                    #(#conditional_rules)*
                 },
                 (None, Some(inner)) => quote! {
                     let __garde_binding = &*#binding;
                     #inner
-                    #(#conditional_rules)*
                 },
                 (Some(outer), None) => quote! {
                     let __garde_binding = &*#binding;
                     #outer
-                    #(#conditional_rules)*
                 },
-                (None, None) => {
-                    if field.conditional_rule_sets.is_empty() {
-                        unreachable!("field should already be skipped")
-                    } else {
-                        quote! {
-                            let __garde_binding = &*#binding;
-                            #(#conditional_rules)*
-                        }
-                    }
-                }
+                (None, None) => unreachable!("field should already be skipped"),
             };
 
             let add = &self.1;

--- a/garde_derive/src/emit.rs
+++ b/garde_derive/src/emit.rs
@@ -459,7 +459,7 @@ where
                             #(#conditional_rules)*
                         }
                     }
-                },
+                }
             };
 
             let add = &self.1;

--- a/garde_derive/src/model.rs
+++ b/garde_derive/src/model.rs
@@ -100,6 +100,12 @@ pub enum RawRuleKind {
     Pattern(Pattern),
     Custom(Expr),
     Inner(List<RawRule>),
+    If(IfRule),
+}
+
+pub struct IfRule {
+    pub condition: Expr,
+    pub rules: List<RawRule>,
 }
 
 pub struct RawLength {
@@ -189,15 +195,21 @@ pub struct ValidateField {
 
     pub dive: Option<(Span, Option<Expr>)>,
     pub rule_set: RuleSet,
+    pub conditional_rule_sets: Vec<ConditionalRuleSet>,
+}
+
+pub struct ConditionalRuleSet {
+    pub condition: Expr,
+    pub rule_set: RuleSet,
 }
 
 impl ValidateField {
     pub fn is_empty(&self) -> bool {
-        self.dive.is_none() && self.rule_set.is_empty()
+        self.dive.is_none() && self.rule_set.is_empty() && self.conditional_rule_sets.is_empty()
     }
 
     pub fn has_top_level_rules(&self) -> bool {
-        self.rule_set.has_top_level_rules()
+        self.rule_set.has_top_level_rules() || !self.conditional_rule_sets.is_empty()
     }
 }
 

--- a/garde_derive/src/model.rs
+++ b/garde_derive/src/model.rs
@@ -195,7 +195,6 @@ pub struct ValidateField {
 
     pub dive: Option<(Span, Option<Expr>)>,
     pub rule_set: RuleSet,
-    pub conditional_rule_sets: Vec<ConditionalRuleSet>,
 }
 
 pub struct ConditionalRuleSet {
@@ -205,11 +204,11 @@ pub struct ConditionalRuleSet {
 
 impl ValidateField {
     pub fn is_empty(&self) -> bool {
-        self.dive.is_none() && self.rule_set.is_empty() && self.conditional_rule_sets.is_empty()
+        self.dive.is_none() && self.rule_set.is_empty()
     }
 
     pub fn has_top_level_rules(&self) -> bool {
-        self.rule_set.has_top_level_rules() || !self.conditional_rule_sets.is_empty()
+        self.rule_set.has_top_level_rules()
     }
 }
 
@@ -217,6 +216,7 @@ pub struct RuleSet {
     pub rules: BTreeSet<ValidateRule>,
     pub custom_rules: Vec<Expr>,
     pub inner: Option<Box<RuleSet>>,
+    pub conditional_rule_sets: Vec<ConditionalRuleSet>,
 }
 
 impl RuleSet {
@@ -225,6 +225,7 @@ impl RuleSet {
             rules: BTreeSet::new(),
             custom_rules: Vec::new(),
             inner: None,
+            conditional_rule_sets: Vec::new(),
         }
     }
 
@@ -233,11 +234,24 @@ impl RuleSet {
             Some(inner) => inner.is_empty(),
             None => true,
         };
-        inner_empty && self.rules.is_empty() && self.custom_rules.is_empty()
+        inner_empty
+            && self.rules.is_empty()
+            && self.custom_rules.is_empty()
+            && self.conditional_rule_sets.is_empty()
     }
 
     pub fn has_top_level_rules(&self) -> bool {
-        !self.rules.is_empty() || !self.custom_rules.is_empty()
+        !self.rules.is_empty()
+            || !self.custom_rules.is_empty()
+            || !self.conditional_rule_sets.is_empty()
+    }
+
+    pub fn has_inner_rules(&self) -> bool {
+        self.inner.is_some()
+            || self
+                .conditional_rule_sets
+                .iter()
+                .any(|conditional| conditional.rule_set.has_inner_rules())
     }
 }
 

--- a/garde_derive/src/syntax.rs
+++ b/garde_derive/src/syntax.rs
@@ -6,7 +6,7 @@ use syn::parse::Parse;
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::token::As;
-use syn::{DeriveInput, Token, Type};
+use syn::{DeriveInput, Expr, Token, Type};
 
 use crate::model;
 use crate::model::List;
@@ -349,6 +349,7 @@ impl Parse for model::RawRule {
                 "pattern" => Pattern(content),
                 "custom" => Custom(content),
                 "inner" => Inner(content),
+                "if" => If(content),
             }
         }
     }
@@ -588,6 +589,36 @@ impl<T: Parse> Parse for List<T> {
             .collect();
 
         Ok(Self { contents })
+    }
+}
+
+impl Parse for model::IfRule {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        // Parse "cond = <expr>,"
+        let cond_ident = input.parse::<Ident>()?;
+        if cond_ident != "cond" {
+            return Err(syn::Error::new(
+                cond_ident.span(),
+                "expected 'cond' in if rule",
+            ));
+        }
+        input.parse::<Token![=]>()?;
+        let condition = input.parse::<Expr>()?;
+        
+        // Expect comma after condition
+        input.parse::<Token![,]>()?;
+        
+        // Parse the remaining rules
+        let rules = input.parse::<List<model::RawRule>>()?;
+        
+        if rules.contents.is_empty() {
+            return Err(syn::Error::new(
+                input.span(),
+                "if rule must contain at least one validation rule",
+            ));
+        }
+        
+        Ok(model::IfRule { condition, rules })
     }
 }
 

--- a/garde_derive/src/syntax.rs
+++ b/garde_derive/src/syntax.rs
@@ -253,104 +253,107 @@ where
 impl Parse for model::RawRule {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
         let ident = Ident::parse_any(input)?;
+        parse_raw_rule(input, ident)
+    }
+}
 
-        macro_rules! error_if_missing_feature {
-            ($rule:literal, $feature:literal) => {
-                #[cfg(not(feature = $feature))]
-                return Err(syn::Error::new(
-                    ident.span(),
-                    concat!(
-                        "validation rule `",
-                        $rule,
-                        "` requires the `",
-                        $feature,
-                        "` feature flag"
-                    ),
-                ));
-            };
+fn parse_raw_rule(input: syn::parse::ParseStream, ident: Ident) -> syn::Result<model::RawRule> {
+    macro_rules! error_if_missing_feature {
+        ($rule:literal, $feature:literal) => {
+            #[cfg(not(feature = $feature))]
+            return Err(syn::Error::new(
+                ident.span(),
+                concat!(
+                    "validation rule `",
+                    $rule,
+                    "` requires the `",
+                    $feature,
+                    "` feature flag"
+                ),
+            ));
+        };
+    }
+
+    match ident.to_string().as_str() {
+        "email" => {
+            error_if_missing_feature!("email", "email");
         }
-
-        match ident.to_string().as_str() {
-            "email" => {
-                error_if_missing_feature!("email", "email");
-            }
-            "url" => {
-                error_if_missing_feature!("url", "url");
-            }
-            "credit_card" => {
-                error_if_missing_feature!("credit_card", "credit-card");
-            }
-            "phone_number" => {
-                error_if_missing_feature!("phone_number", "phone-number");
-            }
-            _ => {}
+        "url" => {
+            error_if_missing_feature!("url", "url");
         }
+        "credit_card" => {
+            error_if_missing_feature!("credit_card", "credit-card");
+        }
+        "phone_number" => {
+            error_if_missing_feature!("phone_number", "phone-number");
+        }
+        _ => {}
+    }
 
-        macro_rules! rules {
-            (($input:ident, $ident:ident) {
-                $($name:literal => $rule:ident $(($content:ident))? $(( ? $content_opt:ident))?,)*
-            }) => {
-                match $ident.to_string().as_str() {
-                    $(
-                        $name => {
-                            $(
-                                let $content;
-                                syn::parenthesized!($content in $input);
-                                let $content = $content.parse()?;
-                            )?
-                            $(
-                                let $content_opt = if $input.peek(syn::token::Paren) {
-                                    let $content_opt;
-                                    syn::parenthesized!($content_opt in $input);
-                                    if $content_opt.is_empty() {
-                                        None
-                                    } else {
-                                        Some($content_opt.parse()?)
-                                    }
-                                } else {
+    macro_rules! rules {
+        (($input:ident, $ident:ident) {
+            $($name:literal => $rule:ident $(($content:ident))? $(( ? $content_opt:ident))?,)*
+        }) => {
+            match $ident.to_string().as_str() {
+                $(
+                    $name => {
+                        $(
+                            let $content;
+                            syn::parenthesized!($content in $input);
+                            let $content = $content.parse()?;
+                        )?
+                        $(
+                            let $content_opt = if $input.peek(syn::token::Paren) {
+                                let $content_opt;
+                                syn::parenthesized!($content_opt in $input);
+                                if $content_opt.is_empty() {
                                     None
-                                };
-                            )?
-                            Ok(model::RawRule {
-                                span: $ident.span(),
-                                kind: model::RawRuleKind::$rule $(($content))? $(($content_opt))?
-                            })
-                        }
-                    )*
-                    _ => Err(syn::Error::new($ident.span(), "unrecognized validation rule")),
-                }
-            };
-        }
-
-        rules! {
-            (input, ident) {
-                "skip" => Skip,
-                "adapt" => Adapt(content),
-                "rename" => Rename(content),
-                // "message" => Message(content),
-                "code" => Code(content),
-                "dive" => Dive(? content),
-                "required" => Required,
-                "ascii" => Ascii,
-                "alphanumeric" => Alphanumeric,
-                "email" => Email,
-                "url" => Url,
-                "ip" => Ip,
-                "ipv4" => IpV4,
-                "ipv6" => IpV6,
-                "credit_card" => CreditCard,
-                "phone_number" => PhoneNumber,
-                "length" => Length(content),
-                "matches" => Matches(content),
-                "range" => Range(content),
-                "contains" => Contains(content),
-                "prefix" => Prefix(content),
-                "suffix" => Suffix(content),
-                "pattern" => Pattern(content),
-                "custom" => Custom(content),
-                "inner" => Inner(content),
-                "if" => If(content),
+                                } else {
+                                    Some($content_opt.parse()?)
+                                }
+                            } else {
+                                None
+                            };
+                        )?
+                        Ok(model::RawRule {
+                            span: $ident.span(),
+                            kind: model::RawRuleKind::$rule $(($content))? $(($content_opt))?
+                        })
+                    }
+                )*
+                _ => Err(syn::Error::new($ident.span(), "unrecognized validation rule")),
             }
+        };
+    }
+
+    rules! {
+        (input, ident) {
+            "skip" => Skip,
+            "adapt" => Adapt(content),
+            "rename" => Rename(content),
+            // "message" => Message(content),
+            "code" => Code(content),
+            "dive" => Dive(? content),
+            "required" => Required,
+            "ascii" => Ascii,
+            "alphanumeric" => Alphanumeric,
+            "email" => Email,
+            "url" => Url,
+            "ip" => Ip,
+            "ipv4" => IpV4,
+            "ipv6" => IpV6,
+            "credit_card" => CreditCard,
+            "phone_number" => PhoneNumber,
+            "length" => Length(content),
+            "matches" => Matches(content),
+            "range" => Range(content),
+            "contains" => Contains(content),
+            "prefix" => Prefix(content),
+            "suffix" => Suffix(content),
+            "pattern" => Pattern(content),
+            "custom" => Custom(content),
+            "inner" => Inner(content),
+            "if" => If(content),
         }
     }
 }
@@ -592,33 +595,58 @@ impl<T: Parse> Parse for List<T> {
     }
 }
 
+enum IfRuleArgument {
+    Cond(Span, Expr),
+    Rule(model::RawRule),
+}
+
+impl Parse for IfRuleArgument {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let ident = Ident::parse_any(input)?;
+        if ident == "cond" && input.peek(Token![=]) {
+            input.parse::<Token![=]>()?;
+            Ok(Self::Cond(ident.span(), input.parse()?))
+        } else {
+            parse_raw_rule(input, ident).map(Self::Rule)
+        }
+    }
+}
+
 impl Parse for model::IfRule {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
-        // Parse "cond = <expr>,"
-        let cond_ident = input.parse::<Ident>()?;
-        if cond_ident != "cond" {
-            return Err(syn::Error::new(
-                cond_ident.span(),
-                "expected 'cond' in if rule",
-            ));
+        let args = Punctuated::<IfRuleArgument, Token![,]>::parse_terminated(input)?;
+        let mut condition = None;
+        let mut rules = Vec::new();
+        let mut error = None;
+
+        for arg in args {
+            match arg {
+                IfRuleArgument::Cond(span, expr) => {
+                    if condition.is_some() {
+                        error.maybe_fold(syn::Error::new(span, "duplicate argument"));
+                    } else {
+                        condition = Some(expr);
+                    }
+                }
+                IfRuleArgument::Rule(rule) => rules.push(rule),
+            }
         }
-        input.parse::<Token![=]>()?;
-        let condition = input.parse::<Expr>()?;
 
-        // Expect comma after condition
-        input.parse::<Token![,]>()?;
-
-        // Parse the remaining rules
-        let rules = input.parse::<List<model::RawRule>>()?;
-
-        if rules.contents.is_empty() {
-            return Err(syn::Error::new(
+        if rules.is_empty() {
+            error.maybe_fold(syn::Error::new(
                 input.span(),
                 "if rule must contain at least one validation rule",
             ));
         }
 
-        Ok(model::IfRule { condition, rules })
+        match (condition, error) {
+            (_, Some(error)) => Err(error),
+            (Some(condition), None) => Ok(model::IfRule {
+                condition,
+                rules: List { contents: rules },
+            }),
+            (None, None) => Err(syn::Error::new(input.span(), "missing `cond` argument")),
+        }
     }
 }
 

--- a/garde_derive/src/syntax.rs
+++ b/garde_derive/src/syntax.rs
@@ -604,20 +604,20 @@ impl Parse for model::IfRule {
         }
         input.parse::<Token![=]>()?;
         let condition = input.parse::<Expr>()?;
-        
+
         // Expect comma after condition
         input.parse::<Token![,]>()?;
-        
+
         // Parse the remaining rules
         let rules = input.parse::<List<model::RawRule>>()?;
-        
+
         if rules.contents.is_empty() {
             return Err(syn::Error::new(
                 input.span(),
                 "if rule must contain at least one validation rule",
             ));
         }
-        
+
         Ok(model::IfRule { condition, rules })
     }
 }

--- a/garde_derive/src/syntax.rs
+++ b/garde_derive/src/syntax.rs
@@ -597,7 +597,7 @@ impl<T: Parse> Parse for List<T> {
 
 enum IfRuleArgument {
     Cond(Span, Expr),
-    Rule(model::RawRule),
+    Rule(Box<model::RawRule>),
 }
 
 impl Parse for IfRuleArgument {
@@ -607,7 +607,7 @@ impl Parse for IfRuleArgument {
             input.parse::<Token![=]>()?;
             Ok(Self::Cond(ident.span(), input.parse()?))
         } else {
-            parse_raw_rule(input, ident).map(Self::Rule)
+            parse_raw_rule(input, ident).map(Box::new).map(Self::Rule)
         }
     }
 }
@@ -628,7 +628,7 @@ impl Parse for model::IfRule {
                         condition = Some(expr);
                     }
                 }
-                IfRuleArgument::Rule(rule) => rules.push(rule),
+                IfRuleArgument::Rule(rule) => rules.push(*rule),
             }
         }
 


### PR DESCRIPTION
close #78

This PR introduces conditional validation functionality to garde, allowing users to apply validation rules only when specific conditions are met. This enables more flexible and dynamic validation logic based on field values or context.

## Syntax:
`#[garde(if(cond = <expression>, <rules>...))]`

### Alternative Syntaxes Considered

#### Option 1: Global scope modifier
`#[garde(ascii, length(min = 3), if(self.enabled))]`
This creates ambiguity about which rules the condition applies to and breaks the independence of individual validation rules.

####  Option 2: Per-rule conditions
`#[garde(ascii(if = self.check_ascii), length(min = 3, if = self.check_length))]`
While this maintains rule independence, it becomes verbose, and less efficient when multiple rules share the same condition.

####  Option 3: Simple wrapper syntax
`#[garde(if(self.enabled, ascii, length(min = 3)))]`
While simpler, this creates order dependency between the condition and rules.
