### PR TITLE
i18n

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,11 @@ jobs:
           shared-key: "rust-stable-test"
 
       - name: Install wasm-bindgen-cli
-        run: cargo install wasm-bindgen-cli
+        run: |
+          VERSION=$(cargo metadata --format-version 1 --locked \
+            | jq -r '.packages[] | select(.name=="wasm-bindgen") | .version')
+          echo "Installing wasm-bindgen-cli v$VERSION (from Cargo.lock)"
+          cargo install --locked wasm-bindgen-cli --version "$VERSION"
 
       - name: Build xtask
         run: cargo build --manifest-path ./xtask/Cargo.toml

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A Rust validation library
 - [Validation rules](#available-validation-rules)
 - [Length modes](#length-modes)
 - [Inner type validation](#inner-type-validation)
+- [I18n](#i18n)
 - [Newtypes](#newtypes)
 - [Handling Option](#handling-option)
 - [Custom validation](#custom-validation)
@@ -240,6 +241,45 @@ struct Test {
     items: Vec<Option<String>>,
 }
 ```
+
+### I18n
+
+Error messages produced by rules may be customized by implementing [`I18n`]:
+
+```rust,ignore
+use garde::{Validate, i18n::{I18n, with_i18n}};
+
+struct Czech;
+
+impl I18n for Czech {
+    fn length_lower_than(&self, _: usize, min: usize) -> String {
+        format!("musí obsahovat alespoň {min} znaků")
+    }
+
+    fn email_invalid(&self, error: &str) -> String {
+        format!("email je neplatný, {error}")
+    }
+
+    // etc.
+}
+
+#[derive(Validate)]
+struct User {
+    #[garde(length(min = 3))]
+    name: String,
+    #[garde(email)]
+    email: String,
+}
+
+let user = User {
+    name: "Jan Novák".to_string(),
+    email: "invalid-email".to_string(),
+};
+
+let result = with_i18n(Czech, || user.validate());
+```
+
+The default implementation is [`i18n::DefaultI18n`], which produces error messages in english.
 
 ### Newtypes
 

--- a/garde/src/i18n.rs
+++ b/garde/src/i18n.rs
@@ -1,0 +1,434 @@
+//! Error message internationalization (i18n).
+//!
+//! This module provides a trait-based system for customizing validation error messages
+//! in different languages or formats. By implementing the [`I18n`] trait, you can provide
+//! custom error messages for validation rules supported by `garde`.
+//!
+//! # Customization
+//!
+//! By default, `garde` uses english error messages via the [`DefaultI18n`] implementation.
+//!
+//! To use custom error messages, implement the [`I18n`] trait, and validate inside a call to [`with_i18n`].
+//!
+//! ```rust,ignore
+//! use std::borrow::Cow;
+//! use std::fmt::Display;
+//! use garde::{Validate, i18n::{I18n, with_i18n}};
+//!
+//! struct Czech;
+//!
+//! impl I18n for Czech {
+//!     fn length_lower_than(&self, min: usize) -> Cow<'static, str> {
+//!         format!("musí obsahovat alespoň {min} znaků").into()
+//!     }
+//!
+//!     fn email_invalid(&self, error: &dyn Display) -> Cow<'static, str> {
+//!         format!("email je neplatný: {error}").into()
+//!     }
+//!
+//!     // etc.
+//! }
+//!
+//! #[derive(Validate)]
+//! struct User {
+//!     #[garde(length(min = 3))]
+//!     name: String,
+//!     #[garde(email)]
+//!     email: String,
+//! }
+//!
+//! let user = User {
+//!     name: "Jan Novák".to_string(),
+//!     email: "invalid-email".to_string(),
+//! };
+//!
+//! let result = with_i18n(Czech, || user.validate());
+//! ```
+
+use std::borrow::Cow;
+use std::cell::Cell;
+use std::fmt::Display;
+use std::mem::transmute;
+use std::ptr::NonNull;
+
+pub use crate::rules::ip::IpKind;
+
+/// Reasons an email value can fail to parse.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum InvalidEmail {
+    Empty,
+    MissingAt,
+    UserLengthExceeded,
+    InvalidUser,
+    DomainLengthExceeded,
+    InvalidDomain,
+}
+
+impl Display for InvalidEmail {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            InvalidEmail::Empty => f.write_str("value is empty"),
+            InvalidEmail::MissingAt => f.write_str("value is missing `@`"),
+            InvalidEmail::UserLengthExceeded => {
+                f.write_str("user length exceeded maximum of 64 characters")
+            }
+            InvalidEmail::InvalidUser => f.write_str("user contains unexpected characters"),
+            InvalidEmail::DomainLengthExceeded => {
+                f.write_str("domain length exceeded maximum of 255 characters")
+            }
+            InvalidEmail::InvalidDomain => f.write_str("domain contains unexpected characters"),
+        }
+    }
+}
+
+/// Reasons a URL value can fail to parse.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum InvalidUrl {
+    EmptyHost,
+    IdnaError,
+    InvalidPort,
+    InvalidIpv4Address,
+    InvalidIpv6Address,
+    InvalidDomainCharacter,
+    RelativeUrlWithoutBase,
+    RelativeUrlWithCannotBeABaseBase,
+    SetHostOnCannotBeABaseUrl,
+    Overflow,
+    Other,
+}
+
+impl Display for InvalidUrl {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            InvalidUrl::EmptyHost => f.write_str("empty host"),
+            InvalidUrl::IdnaError => f.write_str("invalid international domain name"),
+            InvalidUrl::InvalidPort => f.write_str("invalid port number"),
+            InvalidUrl::InvalidIpv4Address => f.write_str("invalid IPv4 address"),
+            InvalidUrl::InvalidIpv6Address => f.write_str("invalid IPv6 address"),
+            InvalidUrl::InvalidDomainCharacter => f.write_str("invalid domain character"),
+            InvalidUrl::RelativeUrlWithoutBase => f.write_str("relative URL without a base"),
+            InvalidUrl::RelativeUrlWithCannotBeABaseBase => {
+                f.write_str("relative URL with a cannot-be-a-base base")
+            }
+            InvalidUrl::SetHostOnCannotBeABaseUrl => {
+                f.write_str("a cannot-be-a-base URL doesn\u{2019}t have a host to set")
+            }
+            InvalidUrl::Overflow => f.write_str("URLs more than 4 GB are not supported"),
+            InvalidUrl::Other => f.write_str("invalid url"),
+        }
+    }
+}
+
+/// Reasons a credit-card value can fail to validate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum InvalidCreditCard {
+    InvalidFormat,
+    InvalidLength,
+    InvalidLuhn,
+    UnknownType,
+    Other,
+}
+
+impl Display for InvalidCreditCard {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            InvalidCreditCard::InvalidFormat => f.write_str("invalid format"),
+            InvalidCreditCard::InvalidLength => f.write_str("invalid length"),
+            InvalidCreditCard::InvalidLuhn => f.write_str("invalid luhn"),
+            InvalidCreditCard::UnknownType => f.write_str("unknown type"),
+            InvalidCreditCard::Other => f.write_str("invalid credit card"),
+        }
+    }
+}
+
+/// Reasons a phone-number value can fail to parse or validate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum InvalidPhoneNumber {
+    /// The number was parsed successfully, but failed validation.
+    Invalid,
+
+    NotANumber,
+    InvalidCountryCode,
+    TooShortAfterIdd,
+    TooShortNsn,
+    TooLong,
+    MalformedInteger,
+    Other,
+}
+
+impl Display for InvalidPhoneNumber {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            InvalidPhoneNumber::Invalid => f.write_str("not a valid phone number"),
+            InvalidPhoneNumber::NotANumber => f.write_str("not a number"),
+            InvalidPhoneNumber::InvalidCountryCode => f.write_str("invalid country code"),
+            InvalidPhoneNumber::TooShortAfterIdd => {
+                f.write_str("the number is too short after IDD")
+            }
+            InvalidPhoneNumber::TooShortNsn => {
+                f.write_str("the number is too short after the country code")
+            }
+            InvalidPhoneNumber::TooLong => f.write_str("the number is too long"),
+            InvalidPhoneNumber::MalformedInteger => {
+                f.write_str("malformed integer part in phone number")
+            }
+            InvalidPhoneNumber::Other => f.write_str("invalid phone number"),
+        }
+    }
+}
+
+/// Trait for providing custom validation error messages.
+///
+/// See the [module-level documentation](crate::i18n) for usage.
+pub trait I18n {
+    /// Rule: `length`
+    fn length_lower_than(&self, min: usize) -> Cow<'static, str>;
+
+    /// Rule: `length`
+    fn length_greater_than(&self, max: usize) -> Cow<'static, str>;
+
+    /// Rule: `range`
+    fn range_lower_than(&self, min: &dyn Display) -> Cow<'static, str>;
+
+    /// Rule: `range`
+    fn range_greater_than(&self, max: &dyn Display) -> Cow<'static, str>;
+
+    /// Rule: `credit_card`
+    fn credit_card_invalid(&self, reason: InvalidCreditCard) -> Cow<'static, str>;
+
+    /// Rule: `pattern`
+    fn pattern_no_match(&self, pattern: &dyn Display) -> Cow<'static, str>;
+
+    /// Rule: `contains`
+    fn contains_missing(&self, pattern: &dyn Display) -> Cow<'static, str>;
+
+    /// Rule: `url`
+    fn url_invalid(&self, reason: InvalidUrl) -> Cow<'static, str>;
+
+    /// Rule: `prefix`
+    fn prefix_missing(&self, pattern: &dyn Display) -> Cow<'static, str>;
+
+    /// Rule: `suffix`
+    fn suffix_missing(&self, pattern: &dyn Display) -> Cow<'static, str>;
+
+    /// Rule: `phone_number`
+    fn phone_number_invalid(&self, reason: InvalidPhoneNumber) -> Cow<'static, str>;
+
+    /// Rule: `ip`
+    fn ip_invalid(&self, kind: IpKind) -> Cow<'static, str>;
+
+    /// Rule: `matches`
+    fn matches_field_mismatch(&self, field: &dyn Display) -> Cow<'static, str>;
+
+    /// Rule: `email`
+    fn email_invalid(&self, reason: InvalidEmail) -> Cow<'static, str>;
+
+    /// Rule: `ascii`
+    fn ascii_invalid(&self) -> Cow<'static, str>;
+
+    /// Rule: `alphanumeric`
+    fn alphanumeric_invalid(&self) -> Cow<'static, str>;
+
+    /// Rule: `required`
+    fn required_not_set(&self) -> Cow<'static, str>;
+}
+
+impl<T: I18n + ?Sized> I18n for &T {
+    #[inline]
+    fn length_lower_than(&self, min: usize) -> Cow<'static, str> {
+        (**self).length_lower_than(min)
+    }
+    #[inline]
+    fn length_greater_than(&self, max: usize) -> Cow<'static, str> {
+        (**self).length_greater_than(max)
+    }
+    #[inline]
+    fn range_lower_than(&self, min: &dyn Display) -> Cow<'static, str> {
+        (**self).range_lower_than(min)
+    }
+    #[inline]
+    fn range_greater_than(&self, max: &dyn Display) -> Cow<'static, str> {
+        (**self).range_greater_than(max)
+    }
+    #[inline]
+    fn credit_card_invalid(&self, reason: InvalidCreditCard) -> Cow<'static, str> {
+        (**self).credit_card_invalid(reason)
+    }
+    #[inline]
+    fn pattern_no_match(&self, pattern: &dyn Display) -> Cow<'static, str> {
+        (**self).pattern_no_match(pattern)
+    }
+    #[inline]
+    fn contains_missing(&self, pattern: &dyn Display) -> Cow<'static, str> {
+        (**self).contains_missing(pattern)
+    }
+    #[inline]
+    fn url_invalid(&self, reason: InvalidUrl) -> Cow<'static, str> {
+        (**self).url_invalid(reason)
+    }
+    #[inline]
+    fn prefix_missing(&self, pattern: &dyn Display) -> Cow<'static, str> {
+        (**self).prefix_missing(pattern)
+    }
+    #[inline]
+    fn suffix_missing(&self, pattern: &dyn Display) -> Cow<'static, str> {
+        (**self).suffix_missing(pattern)
+    }
+    #[inline]
+    fn phone_number_invalid(&self, reason: InvalidPhoneNumber) -> Cow<'static, str> {
+        (**self).phone_number_invalid(reason)
+    }
+    #[inline]
+    fn ip_invalid(&self, kind: IpKind) -> Cow<'static, str> {
+        (**self).ip_invalid(kind)
+    }
+    #[inline]
+    fn matches_field_mismatch(&self, field: &dyn Display) -> Cow<'static, str> {
+        (**self).matches_field_mismatch(field)
+    }
+    #[inline]
+    fn email_invalid(&self, reason: InvalidEmail) -> Cow<'static, str> {
+        (**self).email_invalid(reason)
+    }
+    #[inline]
+    fn ascii_invalid(&self) -> Cow<'static, str> {
+        (**self).ascii_invalid()
+    }
+    #[inline]
+    fn alphanumeric_invalid(&self) -> Cow<'static, str> {
+        (**self).alphanumeric_invalid()
+    }
+    #[inline]
+    fn required_not_set(&self) -> Cow<'static, str> {
+        (**self).required_not_set()
+    }
+}
+
+/// Default implementation of [`I18n`] which provides english error messages.
+pub struct DefaultI18n;
+
+impl I18n for DefaultI18n {
+    fn length_lower_than(&self, min: usize) -> Cow<'static, str> {
+        format!("length is lower than {min}").into()
+    }
+
+    fn length_greater_than(&self, max: usize) -> Cow<'static, str> {
+        format!("length is greater than {max}").into()
+    }
+
+    fn range_lower_than(&self, min: &dyn Display) -> Cow<'static, str> {
+        format!("lower than {min}").into()
+    }
+
+    fn range_greater_than(&self, max: &dyn Display) -> Cow<'static, str> {
+        format!("greater than {max}").into()
+    }
+
+    fn credit_card_invalid(&self, reason: InvalidCreditCard) -> Cow<'static, str> {
+        format!("not a valid credit card number: {reason}").into()
+    }
+
+    fn pattern_no_match(&self, pattern: &dyn Display) -> Cow<'static, str> {
+        format!("does not match pattern /{pattern}/").into()
+    }
+
+    fn contains_missing(&self, pattern: &dyn Display) -> Cow<'static, str> {
+        format!("does not contain \"{pattern}\"").into()
+    }
+
+    fn url_invalid(&self, reason: InvalidUrl) -> Cow<'static, str> {
+        format!("not a valid url: {reason}").into()
+    }
+
+    fn prefix_missing(&self, pattern: &dyn Display) -> Cow<'static, str> {
+        format!("value does not begin with \"{pattern}\"").into()
+    }
+
+    fn suffix_missing(&self, pattern: &dyn Display) -> Cow<'static, str> {
+        format!("does not end with \"{pattern}\"").into()
+    }
+
+    fn phone_number_invalid(&self, reason: InvalidPhoneNumber) -> Cow<'static, str> {
+        match reason {
+            InvalidPhoneNumber::Invalid => Cow::Borrowed("not a valid phone number"),
+            _ => format!("not a valid phone number: {reason}").into(),
+        }
+    }
+
+    fn ip_invalid(&self, kind: IpKind) -> Cow<'static, str> {
+        format!("not a valid {kind} address").into()
+    }
+
+    fn matches_field_mismatch(&self, field: &dyn Display) -> Cow<'static, str> {
+        format!("does not match {field} field").into()
+    }
+
+    fn email_invalid(&self, reason: InvalidEmail) -> Cow<'static, str> {
+        format!("not a valid email: {reason}").into()
+    }
+
+    fn ascii_invalid(&self) -> Cow<'static, str> {
+        Cow::Borrowed("not ascii")
+    }
+
+    fn alphanumeric_invalid(&self) -> Cow<'static, str> {
+        Cow::Borrowed("not alphanumeric")
+    }
+
+    fn required_not_set(&self) -> Cow<'static, str> {
+        Cow::Borrowed("not set")
+    }
+}
+
+thread_local! {
+    pub(crate) static I18N: Cell<Option<NonNull<dyn I18n + 'static>>> =
+        const { Cell::new(None) };
+}
+
+/// Dispatch a method call to the currently-installed [`I18n`] handler.
+macro_rules! i18n {
+    ($handler:ident $(, $($args:expr),*)?) => {
+        $crate::i18n::I18N.with(|slot| match slot.get() {
+            None => <$crate::i18n::DefaultI18n as $crate::i18n::I18n>::$handler(
+                &$crate::i18n::DefaultI18n,
+                $($($args),*)?
+            ),
+            // SAFETY: The stack guard in `with_i18n` guarantees that the value
+            // referenced in `I18N` is still live and safe to dereference at this point.
+            Some(p) => unsafe { p.as_ref() }.$handler($($($args),*)?),
+        })
+    };
+}
+
+/// Execute a closure with a custom [`I18n`] handler.
+///
+/// This handler is only installed for the current thread.
+pub fn with_i18n<'a, R>(mut handler: impl I18n + 'a, f: impl FnOnce() -> R) -> R {
+    let handler: *mut (dyn I18n + 'a) = &raw mut handler;
+
+    // SAFETY: The pointer is non-null for the duration of this stack frame.
+    let ptr: NonNull<dyn I18n + 'static> = unsafe {
+        NonNull::new_unchecked(
+            transmute::<*mut (dyn I18n + 'a), *mut (dyn I18n + 'static)>(handler),
+        )
+    };
+
+    // Stack guard which restores the previous value of `I18N` on drop.
+    struct Reset {
+        prev: Option<NonNull<dyn I18n + 'static>>,
+    }
+    impl Drop for Reset {
+        fn drop(&mut self) {
+            I18N.with(|c| c.set(self.prev));
+        }
+    }
+
+    let _reset = Reset {
+        prev: I18N.with(|c| c.replace(Some(ptr))),
+    };
+    f()
+}

--- a/garde/src/lib.rs
+++ b/garde/src/lib.rs
@@ -1,5 +1,8 @@
 #![doc = include_str!("../README.md")]
 
+#[macro_use]
+pub mod i18n;
+
 pub mod error;
 pub mod rules;
 pub mod validate;
@@ -7,6 +10,7 @@ pub mod validate;
 pub use error::{Error, Path, Report};
 #[cfg(feature = "derive")]
 pub use garde_derive::{select, Validate};
+pub use i18n::{with_i18n, I18n};
 pub use validate::{Unvalidated, Valid, Validate};
 
 pub type Result = ::core::result::Result<(), Error>;

--- a/garde/src/rules/alphanumeric.rs
+++ b/garde/src/rules/alphanumeric.rs
@@ -17,7 +17,7 @@ use crate::error::Error;
 
 pub fn apply<T: Alphanumeric>(v: &T, _: ()) -> Result<(), Error> {
     if !v.validate_alphanumeric() {
-        return Err(Error::new("not alphanumeric"));
+        return Err(Error::new(i18n!(alphanumeric_invalid)));
     }
     Ok(())
 }

--- a/garde/src/rules/ascii.rs
+++ b/garde/src/rules/ascii.rs
@@ -17,7 +17,7 @@ use crate::error::Error;
 
 pub fn apply<T: Ascii>(v: &T, _: ()) -> Result<(), Error> {
     if !v.validate_ascii() {
-        return Err(Error::new("not ascii"));
+        return Err(Error::new(i18n!(ascii_invalid)));
     }
     Ok(())
 }

--- a/garde/src/rules/contains.rs
+++ b/garde/src/rules/contains.rs
@@ -21,7 +21,7 @@ use crate::error::Error;
 
 pub fn apply<T: Contains>(v: &T, (pat,): (&str,)) -> Result<(), Error> {
     if !v.validate_contains(pat) {
-        return Err(Error::new(format!("does not contain \"{pat}\"")));
+        return Err(Error::new(i18n!(contains_missing, &pat)));
     }
     Ok(())
 }

--- a/garde/src/rules/credit_card.rs
+++ b/garde/src/rules/credit_card.rs
@@ -12,37 +12,31 @@
 //!
 //! This trait has a blanket implementation for all `T: garde::rules::AsStr`.
 
-use std::fmt::Display;
-
 use super::AsStr;
 use crate::error::Error;
+pub use crate::i18n::InvalidCreditCard;
 
 pub fn apply<T: CreditCard>(v: &T, _: ()) -> Result<(), Error> {
-    if let Err(e) = v.validate_credit_card() {
-        return Err(Error::new(format!("not a valid credit card number: {e}")));
+    if let Err(reason) = v.validate_credit_card() {
+        return Err(Error::new(i18n!(credit_card_invalid, reason)));
     }
     Ok(())
 }
 
 pub trait CreditCard {
-    type Error: Display;
-
-    fn validate_credit_card(&self) -> Result<(), Self::Error>;
+    fn validate_credit_card(&self) -> Result<(), InvalidCreditCard>;
 }
 
 impl<T: AsStr> CreditCard for T {
-    type Error = InvalidCard;
-
-    fn validate_credit_card(&self) -> Result<(), Self::Error> {
-        let _ = card_validate::Validate::from(self.as_str())?;
-        Ok(())
+    fn validate_credit_card(&self) -> Result<(), InvalidCreditCard> {
+        card_validate::Validate::from(self.as_str())
+            .map(|_| ())
+            .map_err(InvalidCreditCard::from)
     }
 }
 
 impl<T: CreditCard> CreditCard for Option<T> {
-    type Error = T::Error;
-
-    fn validate_credit_card(&self) -> Result<(), Self::Error> {
+    fn validate_credit_card(&self) -> Result<(), InvalidCreditCard> {
         match self {
             Some(value) => value.validate_credit_card(),
             None => Ok(()),
@@ -50,21 +44,14 @@ impl<T: CreditCard> CreditCard for Option<T> {
     }
 }
 
-pub struct InvalidCard(card_validate::ValidateError);
-impl Display for InvalidCard {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match &self.0 {
-            card_validate::ValidateError::InvalidFormat => write!(f, "invalid format"),
-            card_validate::ValidateError::InvalidLength => write!(f, "invalid length"),
-            card_validate::ValidateError::InvalidLuhn => write!(f, "invalid luhn"),
-            card_validate::ValidateError::UnknownType => write!(f, "unknown type"),
-            _ => write!(f, "unknown error"),
+impl From<card_validate::ValidateError> for InvalidCreditCard {
+    fn from(e: card_validate::ValidateError) -> Self {
+        match e {
+            card_validate::ValidateError::InvalidFormat => InvalidCreditCard::InvalidFormat,
+            card_validate::ValidateError::InvalidLength => InvalidCreditCard::InvalidLength,
+            card_validate::ValidateError::InvalidLuhn => InvalidCreditCard::InvalidLuhn,
+            card_validate::ValidateError::UnknownType => InvalidCreditCard::UnknownType,
+            _ => InvalidCreditCard::Other,
         }
-    }
-}
-
-impl From<card_validate::ValidateError> for InvalidCard {
-    fn from(value: card_validate::ValidateError) -> Self {
-        Self(value)
     }
 }

--- a/garde/src/rules/email.rs
+++ b/garde/src/rules/email.rs
@@ -12,12 +12,12 @@
 //!
 //! This trait has a blanket implementation for all `T: garde::rules::AsStr`.
 
-use std::fmt::Display;
 use std::str::FromStr;
 
 use super::pattern::Matcher;
 use super::AsStr;
 use crate::error::Error;
+pub use crate::i18n::InvalidEmail;
 
 macro_rules! init_regex {
     ($var:ident => $p:literal) => {
@@ -33,59 +33,26 @@ macro_rules! init_regex {
 
 pub fn apply<T: Email>(v: &T, _: ()) -> Result<(), Error> {
     if let Err(e) = v.validate_email() {
-        return Err(Error::new(format!("not a valid email: {e}")));
+        return Err(Error::new(i18n!(email_invalid, e)));
     }
     Ok(())
 }
 
 pub trait Email {
-    type Error: Display;
-
-    fn validate_email(&self) -> Result<(), Self::Error>;
+    fn validate_email(&self) -> Result<(), InvalidEmail>;
 }
 
 impl<T: AsStr> Email for T {
-    type Error = InvalidEmail;
-
-    fn validate_email(&self) -> Result<(), Self::Error> {
+    fn validate_email(&self) -> Result<(), InvalidEmail> {
         parse_email(self.as_str())
     }
 }
 
 impl<T: Email> Email for Option<T> {
-    type Error = T::Error;
-
-    fn validate_email(&self) -> Result<(), Self::Error> {
+    fn validate_email(&self) -> Result<(), InvalidEmail> {
         match self {
             Some(value) => value.validate_email(),
             None => Ok(()),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum InvalidEmail {
-    Empty,
-    MissingAt,
-    UserLengthExceeded,
-    InvalidUser,
-    DomainLengthExceeded,
-    InvalidDomain,
-}
-
-impl Display for InvalidEmail {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            InvalidEmail::Empty => write!(f, "value is empty"),
-            InvalidEmail::MissingAt => write!(f, "value is missing `@`"),
-            InvalidEmail::UserLengthExceeded => {
-                write!(f, "user length exceeded maximum of 64 characters")
-            }
-            InvalidEmail::InvalidUser => write!(f, "user contains unexpected characters"),
-            InvalidEmail::DomainLengthExceeded => {
-                write!(f, "domain length exceeded maximum of 255 characters")
-            }
-            InvalidEmail::InvalidDomain => write!(f, "domain contains unexpected characters"),
         }
     }
 }

--- a/garde/src/rules/ip.rs
+++ b/garde/src/rules/ip.rs
@@ -19,7 +19,7 @@ use crate::error::Error;
 
 pub fn apply<T: Ip>(v: &T, (kind,): (IpKind,)) -> Result<(), Error> {
     if v.validate_ip(kind).is_err() {
-        return Err(Error::new(format!("not a valid {kind} address")));
+        return Err(Error::new(i18n!(ip_invalid, kind)));
     }
     Ok(())
 }

--- a/garde/src/rules/length.rs
+++ b/garde/src/rules/length.rs
@@ -63,9 +63,9 @@ use crate::error::Error;
 
 fn check_len(len: usize, min: usize, max: usize) -> Result<(), Error> {
     if len < min {
-        Err(Error::new(format!("length is lower than {min}")))
+        Err(Error::new(i18n!(length_lower_than, min)))
     } else if len > max {
-        Err(Error::new(format!("length is greater than {max}")))
+        Err(Error::new(i18n!(length_greater_than, max)))
     } else {
         Ok(())
     }

--- a/garde/src/rules/matches.rs
+++ b/garde/src/rules/matches.rs
@@ -18,7 +18,7 @@ use crate::Error;
 
 pub fn apply<T: Matches<O>, O>(v: &T, (field, value): (&str, &O)) -> Result<(), Error> {
     if !v.validate_matches(value) {
-        return Err(Error::new(format!("does not match {field} field")));
+        return Err(Error::new(i18n!(matches_field_mismatch, &field)));
     }
     Ok(())
 }

--- a/garde/src/rules/pattern.rs
+++ b/garde/src/rules/pattern.rs
@@ -50,10 +50,7 @@ use crate::error::Error;
 
 pub fn apply<T: Pattern, M: Matcher>(v: &T, (pat,): (&M,)) -> Result<(), Error> {
     if !v.validate_pattern(pat) {
-        return Err(Error::new(format!(
-            "does not match pattern /{}/",
-            pat.as_str()
-        )));
+        return Err(Error::new(i18n!(pattern_no_match, &pat.as_str())));
     }
     Ok(())
 }

--- a/garde/src/rules/phone_number.rs
+++ b/garde/src/rules/phone_number.rs
@@ -12,42 +12,52 @@
 //!
 //! This trait has a blanket implementation for all `T: garde::rules::AsStr`.
 
-use std::fmt::Display;
 use std::str::FromStr;
 
 use super::AsStr;
 use crate::error::Error;
+pub use crate::i18n::InvalidPhoneNumber;
 
 pub fn apply<T: PhoneNumber>(v: &T, _: ()) -> Result<(), Error> {
-    match v.validate_phone_number() {
-        Ok(true) => Ok(()),
-        Ok(false) => Err(Error::new("not a valid phone number")),
-        Err(e) => Err(Error::new(format!("not a valid phone number: {e}"))),
+    if let Err(reason) = v.validate_phone_number() {
+        return Err(Error::new(i18n!(phone_number_invalid, reason)));
     }
+    Ok(())
 }
 
 pub trait PhoneNumber {
-    type Error: Display;
-
-    fn validate_phone_number(&self) -> Result<bool, Self::Error>;
+    fn validate_phone_number(&self) -> Result<(), InvalidPhoneNumber>;
 }
 
 impl<T: AsStr> PhoneNumber for T {
-    type Error = phonenumber::ParseError;
-
-    fn validate_phone_number(&self) -> Result<bool, Self::Error> {
+    fn validate_phone_number(&self) -> Result<(), InvalidPhoneNumber> {
         let number = phonenumber::PhoneNumber::from_str(self.as_str())?;
-        Ok(number.is_valid())
+        if number.is_valid() {
+            Ok(())
+        } else {
+            Err(InvalidPhoneNumber::Invalid)
+        }
     }
 }
 
 impl<T: PhoneNumber> PhoneNumber for Option<T> {
-    type Error = T::Error;
-
-    fn validate_phone_number(&self) -> Result<bool, Self::Error> {
+    fn validate_phone_number(&self) -> Result<(), InvalidPhoneNumber> {
         match self {
             Some(value) => value.validate_phone_number(),
-            None => Ok(true),
+            None => Ok(()),
+        }
+    }
+}
+
+impl From<phonenumber::ParseError> for InvalidPhoneNumber {
+    fn from(e: phonenumber::ParseError) -> Self {
+        match e {
+            phonenumber::ParseError::NoNumber => InvalidPhoneNumber::NotANumber,
+            phonenumber::ParseError::InvalidCountryCode => InvalidPhoneNumber::InvalidCountryCode,
+            phonenumber::ParseError::TooShortAfterIdd => InvalidPhoneNumber::TooShortAfterIdd,
+            phonenumber::ParseError::TooShortNsn => InvalidPhoneNumber::TooShortNsn,
+            phonenumber::ParseError::TooLong => InvalidPhoneNumber::TooLong,
+            phonenumber::ParseError::MalformedInteger(_) => InvalidPhoneNumber::MalformedInteger,
         }
     }
 }

--- a/garde/src/rules/prefix.rs
+++ b/garde/src/rules/prefix.rs
@@ -21,7 +21,7 @@ use crate::error::Error;
 
 pub fn apply<T: Prefix>(v: &T, (pat,): (&str,)) -> Result<(), Error> {
     if !v.validate_prefix(pat) {
-        return Err(Error::new(format!("value does not begin with \"{pat}\"")));
+        return Err(Error::new(i18n!(prefix_missing, &pat)));
     }
     Ok(())
 }

--- a/garde/src/rules/range.rs
+++ b/garde/src/rules/range.rs
@@ -25,8 +25,8 @@ pub fn apply<T: Bounds>(
     let max = max.unwrap_or(T::MAX);
     if let Err(e) = v.validate_bounds(min, max) {
         match e {
-            OutOfBounds::Lower => return Err(Error::new(format!("lower than {min}"))),
-            OutOfBounds::Upper => return Err(Error::new(format!("greater than {max}"))),
+            OutOfBounds::Lower => return Err(Error::new(i18n!(range_lower_than, &min))),
+            OutOfBounds::Upper => return Err(Error::new(i18n!(range_greater_than, &max))),
         }
     }
     Ok(())

--- a/garde/src/rules/required.rs
+++ b/garde/src/rules/required.rs
@@ -2,7 +2,7 @@ use crate::{Error, Result};
 
 pub fn apply<T: Required>(v: &T, _: ()) -> Result {
     if !v.is_set() {
-        return Err(Error::new("not set"));
+        return Err(Error::new(i18n!(required_not_set)));
     }
     Ok(())
 }

--- a/garde/src/rules/suffix.rs
+++ b/garde/src/rules/suffix.rs
@@ -21,7 +21,7 @@ use crate::error::Error;
 
 pub fn apply<T: Suffix>(v: &T, (pat,): (&str,)) -> Result<(), Error> {
     if !v.validate_suffix(pat) {
-        return Err(Error::new(format!("does not end with \"{pat}\"")));
+        return Err(Error::new(i18n!(suffix_missing, &pat)));
     }
     Ok(())
 }

--- a/garde/src/rules/url.rs
+++ b/garde/src/rules/url.rs
@@ -15,40 +15,54 @@
 //! If you need to implement this for a string-like type where a contiguous slice of the entire contents cannot be obtained,
 //! then there is currently no way for you to implement this trait.
 
-use std::fmt::Display;
-
 use super::AsStr;
 use crate::error::Error;
+pub use crate::i18n::InvalidUrl;
 
 pub fn apply<T: Url>(v: &T, _: ()) -> Result<(), Error> {
     if let Err(e) = v.validate_url() {
-        return Err(Error::new(format!("not a valid url: {e}")));
+        return Err(Error::new(i18n!(url_invalid, e)));
     }
     Ok(())
 }
 
 pub trait Url {
-    type Error: Display;
-
-    fn validate_url(&self) -> Result<(), Self::Error>;
+    fn validate_url(&self) -> Result<(), InvalidUrl>;
 }
 
 impl<T: AsStr> Url for T {
-    type Error = url::ParseError;
-
-    fn validate_url(&self) -> Result<(), Self::Error> {
-        let _ = url::Url::parse(self.as_str())?;
-        Ok(())
+    fn validate_url(&self) -> Result<(), InvalidUrl> {
+        url::Url::parse(self.as_str())
+            .map(|_| ())
+            .map_err(InvalidUrl::from)
     }
 }
 
 impl<T: Url> Url for Option<T> {
-    type Error = T::Error;
-
-    fn validate_url(&self) -> Result<(), Self::Error> {
+    fn validate_url(&self) -> Result<(), InvalidUrl> {
         match self {
             Some(value) => value.validate_url(),
             None => Ok(()),
+        }
+    }
+}
+
+impl From<url::ParseError> for InvalidUrl {
+    fn from(e: url::ParseError) -> Self {
+        match e {
+            url::ParseError::EmptyHost => InvalidUrl::EmptyHost,
+            url::ParseError::IdnaError => InvalidUrl::IdnaError,
+            url::ParseError::InvalidPort => InvalidUrl::InvalidPort,
+            url::ParseError::InvalidIpv4Address => InvalidUrl::InvalidIpv4Address,
+            url::ParseError::InvalidIpv6Address => InvalidUrl::InvalidIpv6Address,
+            url::ParseError::InvalidDomainCharacter => InvalidUrl::InvalidDomainCharacter,
+            url::ParseError::RelativeUrlWithoutBase => InvalidUrl::RelativeUrlWithoutBase,
+            url::ParseError::RelativeUrlWithCannotBeABaseBase => {
+                InvalidUrl::RelativeUrlWithCannotBeABaseBase
+            }
+            url::ParseError::SetHostOnCannotBeABaseUrl => InvalidUrl::SetHostOnCannotBeABaseUrl,
+            url::ParseError::Overflow => InvalidUrl::Overflow,
+            _ => InvalidUrl::Other,
         }
     }
 }

--- a/garde/tests/rules/i18n.rs
+++ b/garde/tests/rules/i18n.rs
@@ -1,0 +1,403 @@
+use std::borrow::Cow;
+use std::fmt::Display;
+
+use garde::i18n::{InvalidCreditCard, InvalidEmail, InvalidPhoneNumber, InvalidUrl, IpKind};
+
+use super::util;
+
+struct TestI18n;
+
+impl garde::I18n for TestI18n {
+    fn length_lower_than(&self, min: usize) -> Cow<'static, str> {
+        format!("custom: too short, need at least {min}").into()
+    }
+
+    fn length_greater_than(&self, max: usize) -> Cow<'static, str> {
+        format!("custom: too long, maximum is {max}").into()
+    }
+
+    fn range_lower_than(&self, min: &dyn Display) -> Cow<'static, str> {
+        format!("custom: value too small, minimum is {min}").into()
+    }
+
+    fn range_greater_than(&self, max: &dyn Display) -> Cow<'static, str> {
+        format!("custom: value too large, maximum is {max}").into()
+    }
+
+    fn credit_card_invalid(&self, reason: InvalidCreditCard) -> Cow<'static, str> {
+        format!("custom: invalid credit card - {reason:?}").into()
+    }
+
+    fn pattern_no_match(&self, pattern: &dyn Display) -> Cow<'static, str> {
+        format!("custom: doesn't match /{pattern}/").into()
+    }
+
+    fn contains_missing(&self, pattern: &dyn Display) -> Cow<'static, str> {
+        format!("custom: missing required text '{pattern}'").into()
+    }
+
+    fn url_invalid(&self, reason: InvalidUrl) -> Cow<'static, str> {
+        format!("custom: bad URL - {reason:?}").into()
+    }
+
+    fn prefix_missing(&self, pattern: &dyn Display) -> Cow<'static, str> {
+        format!("custom: must start with '{pattern}'").into()
+    }
+
+    fn suffix_missing(&self, pattern: &dyn Display) -> Cow<'static, str> {
+        format!("custom: must end with '{pattern}'").into()
+    }
+
+    fn phone_number_invalid(&self, reason: InvalidPhoneNumber) -> Cow<'static, str> {
+        format!("custom: phone number error - {reason:?}").into()
+    }
+
+    fn ip_invalid(&self, kind: IpKind) -> Cow<'static, str> {
+        format!("custom: not a valid {kind} IP").into()
+    }
+
+    fn matches_field_mismatch(&self, field: &dyn Display) -> Cow<'static, str> {
+        format!("custom: must match {field}").into()
+    }
+
+    fn email_invalid(&self, reason: InvalidEmail) -> Cow<'static, str> {
+        format!("custom: bad email - {reason:?}").into()
+    }
+
+    fn ascii_invalid(&self) -> Cow<'static, str> {
+        "custom: contains non-ASCII characters".into()
+    }
+
+    fn alphanumeric_invalid(&self) -> Cow<'static, str> {
+        "custom: only letters and numbers allowed".into()
+    }
+
+    fn required_not_set(&self) -> Cow<'static, str> {
+        "custom: this field is required".into()
+    }
+}
+
+#[derive(Debug, garde::Validate)]
+struct User {
+    #[garde(length(min = 3, max = 20))]
+    name: String,
+    #[garde(email)]
+    email: String,
+    #[garde(range(min = 18, max = 120))]
+    age: u32,
+    #[garde(required)]
+    phone: Option<String>,
+}
+
+#[derive(Debug, garde::Validate)]
+struct Address {
+    #[garde(length(min = 5))]
+    street: String,
+    #[garde(length(min = 2))]
+    city: String,
+    #[garde(pattern(r"^[0-9]{5}$"))]
+    zip_code: String,
+}
+
+#[derive(Debug, garde::Validate)]
+struct Profile {
+    #[garde(dive)]
+    user: User,
+    #[garde(dive)]
+    address: Address,
+    #[garde(length(min = 10))]
+    bio: String,
+}
+
+#[test]
+fn test_default_i18n_messages() {
+    use garde::I18n as _;
+    let default = garde::i18n::DefaultI18n;
+
+    insta::assert_snapshot!(default.length_lower_than(5));
+    insta::assert_snapshot!(default.length_greater_than(10));
+    insta::assert_snapshot!(default.range_lower_than(&0));
+    insta::assert_snapshot!(default.range_greater_than(&100));
+    insta::assert_snapshot!(default.credit_card_invalid(InvalidCreditCard::InvalidLuhn));
+    insta::assert_snapshot!(default.pattern_no_match(&"\\d+"));
+    insta::assert_snapshot!(default.contains_missing(&"test"));
+    insta::assert_snapshot!(default.url_invalid(InvalidUrl::EmptyHost));
+    insta::assert_snapshot!(default.prefix_missing(&"http://"));
+    insta::assert_snapshot!(default.suffix_missing(&".com"));
+    insta::assert_snapshot!(default.phone_number_invalid(InvalidPhoneNumber::Invalid));
+    insta::assert_snapshot!(default.phone_number_invalid(InvalidPhoneNumber::TooLong));
+    insta::assert_snapshot!(default.ip_invalid(IpKind::V4));
+    insta::assert_snapshot!(default.matches_field_mismatch(&"password"));
+    insta::assert_snapshot!(default.email_invalid(InvalidEmail::MissingAt));
+    insta::assert_snapshot!(default.ascii_invalid());
+    insta::assert_snapshot!(default.alphanumeric_invalid());
+    insta::assert_snapshot!(default.required_not_set());
+}
+
+#[test]
+fn test_custom_i18n_messages() {
+    use garde::I18n as _;
+    let custom = TestI18n;
+
+    insta::assert_snapshot!(custom.length_lower_than(3));
+    insta::assert_snapshot!(custom.length_greater_than(20));
+    insta::assert_snapshot!(custom.range_lower_than(&1));
+    insta::assert_snapshot!(custom.range_greater_than(&99));
+    insta::assert_snapshot!(custom.credit_card_invalid(InvalidCreditCard::InvalidLength));
+    insta::assert_snapshot!(custom.pattern_no_match(&"[a-z]+"));
+    insta::assert_snapshot!(custom.contains_missing(&"hello"));
+    insta::assert_snapshot!(custom.url_invalid(InvalidUrl::Overflow));
+    insta::assert_snapshot!(custom.prefix_missing(&"www."));
+    insta::assert_snapshot!(custom.suffix_missing(&".org"));
+    insta::assert_snapshot!(custom.phone_number_invalid(InvalidPhoneNumber::Invalid));
+    insta::assert_snapshot!(custom.phone_number_invalid(InvalidPhoneNumber::TooShortNsn));
+    insta::assert_snapshot!(custom.ip_invalid(IpKind::V6));
+    insta::assert_snapshot!(custom.matches_field_mismatch(&"confirm_password"));
+    insta::assert_snapshot!(custom.email_invalid(InvalidEmail::InvalidDomain));
+    insta::assert_snapshot!(custom.ascii_invalid());
+    insta::assert_snapshot!(custom.alphanumeric_invalid());
+    insta::assert_snapshot!(custom.required_not_set());
+}
+
+#[test]
+fn test_simple_validation_with_default_i18n() {
+    util::check_fail!(
+        &[User {
+            name: "Jo".to_string(),
+            email: "invalid-email".to_string(),
+            age: 15,
+            phone: None,
+        }],
+        &(),
+    )
+}
+
+#[test]
+fn test_simple_validation_with_custom_i18n() {
+    garde::with_i18n(TestI18n, || {
+        util::check_fail!(
+            &[User {
+                name: "Jo".to_string(),
+                email: "invalid-email".to_string(),
+                age: 15,
+                phone: None,
+            }],
+            &(),
+        )
+    });
+}
+
+#[test]
+fn test_nested_validation_with_default_i18n() {
+    util::check_fail!(
+        &[Profile {
+            user: User {
+                name: "A".to_string(),
+                email: "bad-email".to_string(),
+                age: 200,
+                phone: None,
+            },
+            address: Address {
+                street: "St".to_string(),
+                city: "X".to_string(),
+                zip_code: "123".to_string(),
+            },
+            bio: "Short".to_string(),
+        }],
+        &(),
+    )
+}
+
+#[test]
+fn test_nested_validation_with_custom_i18n() {
+    garde::with_i18n(TestI18n, || {
+        util::check_fail!(
+            &[Profile {
+                user: User {
+                    name: "A".to_string(),
+                    email: "bad-email".to_string(),
+                    age: 200,
+                    phone: None,
+                },
+                address: Address {
+                    street: "St".to_string(),
+                    city: "X".to_string(),
+                    zip_code: "123".to_string(),
+                },
+                bio: "Short".to_string(),
+            }],
+            &(),
+        )
+    });
+}
+
+#[derive(Debug, garde::Validate)]
+struct TooShort {
+    #[garde(length(min = 5))]
+    s: String,
+}
+
+fn first_error_message<T: garde::Validate<Context = ()>>(v: &T) -> String {
+    let report = v.validate().unwrap_err();
+    let (_path, err) = report.iter().next().expect("expected at least one error");
+    err.to_string()
+}
+
+/// `length_lower_than` is overridden; everything else forwards to `DefaultI18n`.
+struct LengthOnly(&'static str);
+
+impl garde::I18n for LengthOnly {
+    fn length_lower_than(&self, min: usize) -> Cow<'static, str> {
+        format!("{}:{min}", self.0).into()
+    }
+    fn length_greater_than(&self, m: usize) -> Cow<'static, str> {
+        garde::i18n::DefaultI18n.length_greater_than(m)
+    }
+    fn range_lower_than(&self, x: &dyn Display) -> Cow<'static, str> {
+        garde::i18n::DefaultI18n.range_lower_than(x)
+    }
+    fn range_greater_than(&self, x: &dyn Display) -> Cow<'static, str> {
+        garde::i18n::DefaultI18n.range_greater_than(x)
+    }
+    fn credit_card_invalid(&self, r: InvalidCreditCard) -> Cow<'static, str> {
+        garde::i18n::DefaultI18n.credit_card_invalid(r)
+    }
+    fn pattern_no_match(&self, x: &dyn Display) -> Cow<'static, str> {
+        garde::i18n::DefaultI18n.pattern_no_match(x)
+    }
+    fn contains_missing(&self, x: &dyn Display) -> Cow<'static, str> {
+        garde::i18n::DefaultI18n.contains_missing(x)
+    }
+    fn url_invalid(&self, r: InvalidUrl) -> Cow<'static, str> {
+        garde::i18n::DefaultI18n.url_invalid(r)
+    }
+    fn prefix_missing(&self, x: &dyn Display) -> Cow<'static, str> {
+        garde::i18n::DefaultI18n.prefix_missing(x)
+    }
+    fn suffix_missing(&self, x: &dyn Display) -> Cow<'static, str> {
+        garde::i18n::DefaultI18n.suffix_missing(x)
+    }
+    fn phone_number_invalid(&self, r: InvalidPhoneNumber) -> Cow<'static, str> {
+        garde::i18n::DefaultI18n.phone_number_invalid(r)
+    }
+    fn ip_invalid(&self, k: IpKind) -> Cow<'static, str> {
+        garde::i18n::DefaultI18n.ip_invalid(k)
+    }
+    fn matches_field_mismatch(&self, x: &dyn Display) -> Cow<'static, str> {
+        garde::i18n::DefaultI18n.matches_field_mismatch(x)
+    }
+    fn email_invalid(&self, r: InvalidEmail) -> Cow<'static, str> {
+        garde::i18n::DefaultI18n.email_invalid(r)
+    }
+    fn ascii_invalid(&self) -> Cow<'static, str> {
+        garde::i18n::DefaultI18n.ascii_invalid()
+    }
+    fn alphanumeric_invalid(&self) -> Cow<'static, str> {
+        garde::i18n::DefaultI18n.alphanumeric_invalid()
+    }
+    fn required_not_set(&self) -> Cow<'static, str> {
+        garde::i18n::DefaultI18n.required_not_set()
+    }
+}
+
+#[test]
+fn test_nesting_restores_outer_handler() {
+    let v = TooShort { s: "ab".into() };
+
+    assert_eq!(first_error_message(&v), "length is lower than 5");
+
+    garde::with_i18n(LengthOnly("OUTER"), || {
+        assert_eq!(first_error_message(&v), "OUTER:5");
+
+        garde::with_i18n(LengthOnly("INNER"), || {
+            assert_eq!(first_error_message(&v), "INNER:5");
+        });
+
+        // Outer must be restored after inner exits.
+        assert_eq!(first_error_message(&v), "OUTER:5");
+    });
+
+    // And cleared after the outermost scope.
+    assert_eq!(first_error_message(&v), "length is lower than 5");
+}
+
+#[test]
+fn test_panic_safety() {
+    let v = TooShort { s: "ab".into() };
+
+    let _ = std::panic::catch_unwind(|| {
+        garde::with_i18n(LengthOnly("OUTER"), || panic!("boom"));
+    });
+
+    // If the slot weren't cleared on unwind, this would say "OUTER:5".
+    assert_eq!(first_error_message(&v), "length is lower than 5");
+}
+
+#[test]
+fn test_borrowed_handler() {
+    // Non-'static handler via the `impl<T: I18n + ?Sized> I18n for &T` blanket.
+    let label = String::from("cs-CZ");
+    // Leak-free borrow: the &str lives in `label`, which outlives `with_i18n`.
+    let prefix: &str = label.as_str();
+
+    struct Borrowed<'a>(&'a str);
+    impl<'a> garde::I18n for Borrowed<'a> {
+        fn length_lower_than(&self, min: usize) -> Cow<'static, str> {
+            format!("[{}] {min}", self.0).into()
+        }
+        fn length_greater_than(&self, m: usize) -> Cow<'static, str> {
+            garde::i18n::DefaultI18n.length_greater_than(m)
+        }
+        fn range_lower_than(&self, x: &dyn Display) -> Cow<'static, str> {
+            garde::i18n::DefaultI18n.range_lower_than(x)
+        }
+        fn range_greater_than(&self, x: &dyn Display) -> Cow<'static, str> {
+            garde::i18n::DefaultI18n.range_greater_than(x)
+        }
+        fn credit_card_invalid(&self, r: InvalidCreditCard) -> Cow<'static, str> {
+            garde::i18n::DefaultI18n.credit_card_invalid(r)
+        }
+        fn pattern_no_match(&self, x: &dyn Display) -> Cow<'static, str> {
+            garde::i18n::DefaultI18n.pattern_no_match(x)
+        }
+        fn contains_missing(&self, x: &dyn Display) -> Cow<'static, str> {
+            garde::i18n::DefaultI18n.contains_missing(x)
+        }
+        fn url_invalid(&self, r: InvalidUrl) -> Cow<'static, str> {
+            garde::i18n::DefaultI18n.url_invalid(r)
+        }
+        fn prefix_missing(&self, x: &dyn Display) -> Cow<'static, str> {
+            garde::i18n::DefaultI18n.prefix_missing(x)
+        }
+        fn suffix_missing(&self, x: &dyn Display) -> Cow<'static, str> {
+            garde::i18n::DefaultI18n.suffix_missing(x)
+        }
+        fn phone_number_invalid(&self, r: InvalidPhoneNumber) -> Cow<'static, str> {
+            garde::i18n::DefaultI18n.phone_number_invalid(r)
+        }
+        fn ip_invalid(&self, k: IpKind) -> Cow<'static, str> {
+            garde::i18n::DefaultI18n.ip_invalid(k)
+        }
+        fn matches_field_mismatch(&self, x: &dyn Display) -> Cow<'static, str> {
+            garde::i18n::DefaultI18n.matches_field_mismatch(x)
+        }
+        fn email_invalid(&self, r: InvalidEmail) -> Cow<'static, str> {
+            garde::i18n::DefaultI18n.email_invalid(r)
+        }
+        fn ascii_invalid(&self) -> Cow<'static, str> {
+            garde::i18n::DefaultI18n.ascii_invalid()
+        }
+        fn alphanumeric_invalid(&self) -> Cow<'static, str> {
+            garde::i18n::DefaultI18n.alphanumeric_invalid()
+        }
+        fn required_not_set(&self) -> Cow<'static, str> {
+            garde::i18n::DefaultI18n.required_not_set()
+        }
+    }
+
+    let b = Borrowed(prefix);
+    let v = TooShort { s: "ab".into() };
+    garde::with_i18n(&b, || {
+        assert_eq!(first_error_message(&v), "[cs-CZ] 5");
+    });
+}

--- a/garde/tests/rules/mod.rs
+++ b/garde/tests/rules/mod.rs
@@ -9,6 +9,7 @@ mod dive;
 mod dive_with_ctx;
 mod dive_with_rules;
 mod email;
+mod i18n;
 mod if_conditional;
 mod inner;
 mod ip;

--- a/garde/tests/rules/snapshots/rules__rules__credit_card__credit_card_invalid.snap
+++ b/garde/tests/rules/snapshots/rules__rules__credit_card__credit_card_invalid.snap
@@ -19,5 +19,3 @@ Test {
 }
 field: not a valid credit card number: invalid luhn
 inner[0]: not a valid credit card number: invalid luhn
-
-

--- a/garde/tests/rules/snapshots/rules__rules__i18n__custom_i18n_messages-10.snap
+++ b/garde/tests/rules/snapshots/rules__rules__i18n__custom_i18n_messages-10.snap
@@ -1,0 +1,5 @@
+---
+source: garde/tests/./rules/i18n.rs
+expression: "custom.suffix_missing(\".org\")"
+---
+custom: must end with '.org'

--- a/garde/tests/rules/snapshots/rules__rules__i18n__custom_i18n_messages-11.snap
+++ b/garde/tests/rules/snapshots/rules__rules__i18n__custom_i18n_messages-11.snap
@@ -1,0 +1,5 @@
+---
+source: garde/tests/./rules/i18n.rs
+expression: "custom.phone_number_invalid(InvalidPhoneNumber::Invalid)"
+---
+custom: phone number error - Invalid

--- a/garde/tests/rules/snapshots/rules__rules__i18n__custom_i18n_messages-12.snap
+++ b/garde/tests/rules/snapshots/rules__rules__i18n__custom_i18n_messages-12.snap
@@ -1,0 +1,5 @@
+---
+source: garde/tests/./rules/i18n.rs
+expression: "custom.phone_number_invalid(InvalidPhoneNumber::TooShortNsn)"
+---
+custom: phone number error - TooShortNsn

--- a/garde/tests/rules/snapshots/rules__rules__i18n__custom_i18n_messages-13.snap
+++ b/garde/tests/rules/snapshots/rules__rules__i18n__custom_i18n_messages-13.snap
@@ -1,0 +1,5 @@
+---
+source: garde/tests/./rules/i18n.rs
+expression: "custom.ip_invalid(\"IPv6\")"
+---
+custom: not a valid IPv6 IP

--- a/garde/tests/rules/snapshots/rules__rules__i18n__custom_i18n_messages-14.snap
+++ b/garde/tests/rules/snapshots/rules__rules__i18n__custom_i18n_messages-14.snap
@@ -1,0 +1,5 @@
+---
+source: garde/tests/./rules/i18n.rs
+expression: "custom.matches_field_mismatch(\"confirm_password\")"
+---
+custom: must match confirm_password

--- a/garde/tests/rules/snapshots/rules__rules__i18n__custom_i18n_messages-15.snap
+++ b/garde/tests/rules/snapshots/rules__rules__i18n__custom_i18n_messages-15.snap
@@ -1,0 +1,5 @@
+---
+source: garde/tests/./rules/i18n.rs
+expression: "custom.email_invalid(InvalidEmail::InvalidDomain)"
+---
+custom: bad email - InvalidDomain

--- a/garde/tests/rules/snapshots/rules__rules__i18n__custom_i18n_messages-16.snap
+++ b/garde/tests/rules/snapshots/rules__rules__i18n__custom_i18n_messages-16.snap
@@ -1,0 +1,5 @@
+---
+source: garde/tests/./rules/i18n.rs
+expression: custom.ascii_invalid()
+---
+custom: contains non-ASCII characters

--- a/garde/tests/rules/snapshots/rules__rules__i18n__custom_i18n_messages-17.snap
+++ b/garde/tests/rules/snapshots/rules__rules__i18n__custom_i18n_messages-17.snap
@@ -1,0 +1,5 @@
+---
+source: garde/tests/./rules/i18n.rs
+expression: custom.alphanumeric_invalid()
+---
+custom: only letters and numbers allowed

--- a/garde/tests/rules/snapshots/rules__rules__i18n__custom_i18n_messages-18.snap
+++ b/garde/tests/rules/snapshots/rules__rules__i18n__custom_i18n_messages-18.snap
@@ -1,0 +1,5 @@
+---
+source: garde/tests/./rules/i18n.rs
+expression: custom.required_not_set()
+---
+custom: this field is required

--- a/garde/tests/rules/snapshots/rules__rules__i18n__custom_i18n_messages-2.snap
+++ b/garde/tests/rules/snapshots/rules__rules__i18n__custom_i18n_messages-2.snap
@@ -1,0 +1,5 @@
+---
+source: garde/tests/./rules/i18n.rs
+expression: custom.length_greater_than(20)
+---
+custom: too long, maximum is 20

--- a/garde/tests/rules/snapshots/rules__rules__i18n__custom_i18n_messages-3.snap
+++ b/garde/tests/rules/snapshots/rules__rules__i18n__custom_i18n_messages-3.snap
@@ -1,0 +1,5 @@
+---
+source: garde/tests/./rules/i18n.rs
+expression: "custom.range_lower_than(\"1\")"
+---
+custom: value too small, minimum is 1

--- a/garde/tests/rules/snapshots/rules__rules__i18n__custom_i18n_messages-4.snap
+++ b/garde/tests/rules/snapshots/rules__rules__i18n__custom_i18n_messages-4.snap
@@ -1,0 +1,5 @@
+---
+source: garde/tests/./rules/i18n.rs
+expression: "custom.range_greater_than(\"99\")"
+---
+custom: value too large, maximum is 99

--- a/garde/tests/rules/snapshots/rules__rules__i18n__custom_i18n_messages-5.snap
+++ b/garde/tests/rules/snapshots/rules__rules__i18n__custom_i18n_messages-5.snap
@@ -1,0 +1,5 @@
+---
+source: garde/tests/./rules/i18n.rs
+expression: "custom.credit_card_invalid(InvalidCreditCard::InvalidLength)"
+---
+custom: invalid credit card - InvalidLength

--- a/garde/tests/rules/snapshots/rules__rules__i18n__custom_i18n_messages-6.snap
+++ b/garde/tests/rules/snapshots/rules__rules__i18n__custom_i18n_messages-6.snap
@@ -1,0 +1,5 @@
+---
+source: garde/tests/./rules/i18n.rs
+expression: "custom.pattern_no_match(\"[a-z]+\")"
+---
+custom: doesn't match /[a-z]+/

--- a/garde/tests/rules/snapshots/rules__rules__i18n__custom_i18n_messages-7.snap
+++ b/garde/tests/rules/snapshots/rules__rules__i18n__custom_i18n_messages-7.snap
@@ -1,0 +1,5 @@
+---
+source: garde/tests/./rules/i18n.rs
+expression: "custom.contains_missing(\"hello\")"
+---
+custom: missing required text 'hello'

--- a/garde/tests/rules/snapshots/rules__rules__i18n__custom_i18n_messages-8.snap
+++ b/garde/tests/rules/snapshots/rules__rules__i18n__custom_i18n_messages-8.snap
@@ -1,0 +1,5 @@
+---
+source: garde/tests/./rules/i18n.rs
+expression: "custom.url_invalid(InvalidUrl::Overflow)"
+---
+custom: bad URL - Overflow

--- a/garde/tests/rules/snapshots/rules__rules__i18n__custom_i18n_messages-9.snap
+++ b/garde/tests/rules/snapshots/rules__rules__i18n__custom_i18n_messages-9.snap
@@ -1,0 +1,5 @@
+---
+source: garde/tests/./rules/i18n.rs
+expression: "custom.prefix_missing(\"www.\")"
+---
+custom: must start with 'www.'

--- a/garde/tests/rules/snapshots/rules__rules__i18n__custom_i18n_messages.snap
+++ b/garde/tests/rules/snapshots/rules__rules__i18n__custom_i18n_messages.snap
@@ -1,0 +1,5 @@
+---
+source: garde/tests/./rules/i18n.rs
+expression: custom.length_lower_than(3)
+---
+custom: too short, need at least 3

--- a/garde/tests/rules/snapshots/rules__rules__i18n__default_i18n_messages-10.snap
+++ b/garde/tests/rules/snapshots/rules__rules__i18n__default_i18n_messages-10.snap
@@ -1,0 +1,5 @@
+---
+source: garde/tests/./rules/i18n.rs
+expression: "default.suffix_missing(\".com\")"
+---
+does not end with ".com"

--- a/garde/tests/rules/snapshots/rules__rules__i18n__default_i18n_messages-11.snap
+++ b/garde/tests/rules/snapshots/rules__rules__i18n__default_i18n_messages-11.snap
@@ -1,0 +1,5 @@
+---
+source: garde/tests/./rules/i18n.rs
+expression: "default.phone_number_invalid(InvalidPhoneNumber::Invalid)"
+---
+not a valid phone number

--- a/garde/tests/rules/snapshots/rules__rules__i18n__default_i18n_messages-12.snap
+++ b/garde/tests/rules/snapshots/rules__rules__i18n__default_i18n_messages-12.snap
@@ -1,0 +1,5 @@
+---
+source: garde/tests/./rules/i18n.rs
+expression: "default.phone_number_invalid(InvalidPhoneNumber::TooLong)"
+---
+not a valid phone number: the number is too long

--- a/garde/tests/rules/snapshots/rules__rules__i18n__default_i18n_messages-13.snap
+++ b/garde/tests/rules/snapshots/rules__rules__i18n__default_i18n_messages-13.snap
@@ -1,0 +1,5 @@
+---
+source: garde/tests/./rules/i18n.rs
+expression: "default.ip_invalid(\"IPv4\")"
+---
+not a valid IPv4 address

--- a/garde/tests/rules/snapshots/rules__rules__i18n__default_i18n_messages-14.snap
+++ b/garde/tests/rules/snapshots/rules__rules__i18n__default_i18n_messages-14.snap
@@ -1,0 +1,5 @@
+---
+source: garde/tests/./rules/i18n.rs
+expression: "default.matches_field_mismatch(\"password\")"
+---
+does not match password field

--- a/garde/tests/rules/snapshots/rules__rules__i18n__default_i18n_messages-15.snap
+++ b/garde/tests/rules/snapshots/rules__rules__i18n__default_i18n_messages-15.snap
@@ -1,0 +1,5 @@
+---
+source: garde/tests/./rules/i18n.rs
+expression: "default.email_invalid(InvalidEmail::MissingAt)"
+---
+not a valid email: value is missing `@`

--- a/garde/tests/rules/snapshots/rules__rules__i18n__default_i18n_messages-16.snap
+++ b/garde/tests/rules/snapshots/rules__rules__i18n__default_i18n_messages-16.snap
@@ -1,0 +1,5 @@
+---
+source: garde/tests/./rules/i18n.rs
+expression: default.ascii_invalid()
+---
+not ascii

--- a/garde/tests/rules/snapshots/rules__rules__i18n__default_i18n_messages-17.snap
+++ b/garde/tests/rules/snapshots/rules__rules__i18n__default_i18n_messages-17.snap
@@ -1,0 +1,5 @@
+---
+source: garde/tests/./rules/i18n.rs
+expression: default.alphanumeric_invalid()
+---
+not alphanumeric

--- a/garde/tests/rules/snapshots/rules__rules__i18n__default_i18n_messages-18.snap
+++ b/garde/tests/rules/snapshots/rules__rules__i18n__default_i18n_messages-18.snap
@@ -1,0 +1,5 @@
+---
+source: garde/tests/./rules/i18n.rs
+expression: default.required_not_set()
+---
+not set

--- a/garde/tests/rules/snapshots/rules__rules__i18n__default_i18n_messages-2.snap
+++ b/garde/tests/rules/snapshots/rules__rules__i18n__default_i18n_messages-2.snap
@@ -1,0 +1,5 @@
+---
+source: garde/tests/./rules/i18n.rs
+expression: default.length_greater_than(10)
+---
+length is greater than 10

--- a/garde/tests/rules/snapshots/rules__rules__i18n__default_i18n_messages-3.snap
+++ b/garde/tests/rules/snapshots/rules__rules__i18n__default_i18n_messages-3.snap
@@ -1,0 +1,5 @@
+---
+source: garde/tests/./rules/i18n.rs
+expression: "default.range_lower_than(\"0\")"
+---
+lower than 0

--- a/garde/tests/rules/snapshots/rules__rules__i18n__default_i18n_messages-4.snap
+++ b/garde/tests/rules/snapshots/rules__rules__i18n__default_i18n_messages-4.snap
@@ -1,0 +1,5 @@
+---
+source: garde/tests/./rules/i18n.rs
+expression: "default.range_greater_than(\"100\")"
+---
+greater than 100

--- a/garde/tests/rules/snapshots/rules__rules__i18n__default_i18n_messages-5.snap
+++ b/garde/tests/rules/snapshots/rules__rules__i18n__default_i18n_messages-5.snap
@@ -1,0 +1,5 @@
+---
+source: garde/tests/./rules/i18n.rs
+expression: "default.credit_card_invalid(InvalidCreditCard::InvalidLuhn)"
+---
+not a valid credit card number: invalid luhn

--- a/garde/tests/rules/snapshots/rules__rules__i18n__default_i18n_messages-6.snap
+++ b/garde/tests/rules/snapshots/rules__rules__i18n__default_i18n_messages-6.snap
@@ -1,0 +1,5 @@
+---
+source: garde/tests/./rules/i18n.rs
+expression: "default.pattern_no_match(\"\\\\d+\")"
+---
+does not match pattern /\d+/

--- a/garde/tests/rules/snapshots/rules__rules__i18n__default_i18n_messages-7.snap
+++ b/garde/tests/rules/snapshots/rules__rules__i18n__default_i18n_messages-7.snap
@@ -1,0 +1,5 @@
+---
+source: garde/tests/./rules/i18n.rs
+expression: "default.contains_missing(\"test\")"
+---
+does not contain "test"

--- a/garde/tests/rules/snapshots/rules__rules__i18n__default_i18n_messages-8.snap
+++ b/garde/tests/rules/snapshots/rules__rules__i18n__default_i18n_messages-8.snap
@@ -1,0 +1,5 @@
+---
+source: garde/tests/./rules/i18n.rs
+expression: "default.url_invalid(InvalidUrl::EmptyHost)"
+---
+not a valid url: empty host

--- a/garde/tests/rules/snapshots/rules__rules__i18n__default_i18n_messages-9.snap
+++ b/garde/tests/rules/snapshots/rules__rules__i18n__default_i18n_messages-9.snap
@@ -1,0 +1,5 @@
+---
+source: garde/tests/./rules/i18n.rs
+expression: "default.prefix_missing(\"http://\")"
+---
+value does not begin with "http://"

--- a/garde/tests/rules/snapshots/rules__rules__i18n__default_i18n_messages.snap
+++ b/garde/tests/rules/snapshots/rules__rules__i18n__default_i18n_messages.snap
@@ -1,0 +1,5 @@
+---
+source: garde/tests/./rules/i18n.rs
+expression: default.length_lower_than(5)
+---
+length is lower than 5

--- a/garde/tests/rules/snapshots/rules__rules__i18n__nested_validation_with_custom_i18n.snap
+++ b/garde/tests/rules/snapshots/rules__rules__i18n__nested_validation_with_custom_i18n.snap
@@ -1,0 +1,26 @@
+---
+source: garde/tests/./rules/i18n.rs
+expression: snapshot
+---
+Profile {
+    user: User {
+        name: "A",
+        email: "bad-email",
+        age: 200,
+        phone: None,
+    },
+    address: Address {
+        street: "St",
+        city: "X",
+        zip_code: "123",
+    },
+    bio: "Short",
+}
+address.city: custom: too short, need at least 2
+address.street: custom: too short, need at least 5
+address.zip_code: custom: doesn't match /^[0-9]{5}$/
+bio: custom: too short, need at least 10
+user.age: custom: value too large, maximum is 120
+user.email: custom: bad email - MissingAt
+user.name: custom: too short, need at least 3
+user.phone: custom: this field is required

--- a/garde/tests/rules/snapshots/rules__rules__i18n__nested_validation_with_default_i18n.snap
+++ b/garde/tests/rules/snapshots/rules__rules__i18n__nested_validation_with_default_i18n.snap
@@ -1,0 +1,26 @@
+---
+source: garde/tests/./rules/i18n.rs
+expression: snapshot
+---
+Profile {
+    user: User {
+        name: "A",
+        email: "bad-email",
+        age: 200,
+        phone: None,
+    },
+    address: Address {
+        street: "St",
+        city: "X",
+        zip_code: "123",
+    },
+    bio: "Short",
+}
+address.city: length is lower than 2
+address.street: length is lower than 5
+address.zip_code: does not match pattern /^[0-9]{5}$/
+bio: length is lower than 10
+user.age: greater than 120
+user.email: not a valid email: value is missing `@`
+user.name: length is lower than 3
+user.phone: not set

--- a/garde/tests/rules/snapshots/rules__rules__i18n__simple_validation_with_custom_i18n.snap
+++ b/garde/tests/rules/snapshots/rules__rules__i18n__simple_validation_with_custom_i18n.snap
@@ -1,0 +1,14 @@
+---
+source: garde/tests/./rules/i18n.rs
+expression: snapshot
+---
+User {
+    name: "Jo",
+    email: "invalid-email",
+    age: 15,
+    phone: None,
+}
+age: custom: value too small, minimum is 18
+email: custom: bad email - MissingAt
+name: custom: too short, need at least 3
+phone: custom: this field is required

--- a/garde/tests/rules/snapshots/rules__rules__i18n__simple_validation_with_default_i18n.snap
+++ b/garde/tests/rules/snapshots/rules__rules__i18n__simple_validation_with_default_i18n.snap
@@ -1,0 +1,14 @@
+---
+source: garde/tests/./rules/i18n.rs
+expression: snapshot
+---
+User {
+    name: "Jo",
+    email: "invalid-email",
+    age: 15,
+    phone: None,
+}
+age: lower than 18
+email: not a valid email: value is missing `@`
+name: length is lower than 3
+phone: not set


### PR DESCRIPTION
* Closes #7 

Adds an API for customizing error messages. This can be used to both customize the defaults in english and also as a way to translate error messages. The default implementation uses the same error messages as before.

The core trait is `garde::I18n`, which contains one method for each error path in each rule. An implementation of this trait is installed via `garde::with_i18n`.

```rust
use garde::{Validate, i18n::{I18n, with_i18n}};

struct Czech;

impl I18n for Czech {
    fn length_lower_than(&self, min: usize) -> String {
        format!("musí obsahovat alespoň {min} znaků")
    }

    fn email_invalid(&self, _error: &str) -> String {
        format!("email je neplatný")
    }

    // etc.
}

#[derive(Validate)]
struct User {
    #[garde(length(min = 3))]
    name: String,
    #[garde(email)]
    email: String,
}

let user = User {
    name: "Jan Novák".to_string(),
    email: "invalid-email".to_string(),
};

let result = with_i18n(Czech, || user.validate());
```

It is possible for the handler passed to `with_i18n` to hold state, which allows for patterns like storing translations in an external file (e.g. [fluent](https://projectfluent.org/)), and running arbitrary code within each error message factory method.