### PR TITLE
Async support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+.*
+!.cargo
+!.gitignore
+
 /target
 /Cargo.lock
 *.snap.new

--- a/garde/Cargo.toml
+++ b/garde/Cargo.toml
@@ -59,6 +59,7 @@ rust_decimal = { version = "1", optional = true }
 js-sys = { version = "0.3", optional = true }
 
 [dev-dependencies]
+tokio = { version = "1.48", features = ["full"]} # TODO: Full not needed
 trybuild = { version = "1.0" }
 insta = { version = "1.29" }
 owo-colors = { version = "4" }

--- a/garde/src/async_validate.rs
+++ b/garde/src/async_validate.rs
@@ -1,0 +1,180 @@
+//! ## Core validation traits and types
+
+use std::fmt::Debug;
+use std::future::Future;
+
+use crate::error::Path;
+use crate::{Report, Valid};
+
+pub type AsyncParentFn<'a> = dyn FnMut() -> Path + Send + 'a;
+/// The core trait of this crate.
+///
+/// Validation runs the fields through every validation rules,
+/// and aggregates any errors into a [`Report`].
+pub trait AsyncValidate: Send + Sync {
+    /// A user-provided context.
+    ///
+    /// Custom validators receive a reference to this context.
+    type Context: Send + Sync;
+
+    /// Validates `Self`, returning an `Err` with an aggregate of all errors if
+    /// the validation failed.
+    ///
+    /// This method should not be implemented manually. Implement [`AsyncValidate::validate_into`] instead,
+    /// because [`AsyncValidate::validate`] has a default implementation that calls [`AsyncValidate::validate_into`].
+    fn validate(&self) -> impl Future<Output = Result<(), Report>> + Send
+    where
+        Self::Context: Default,
+    {
+        async {
+            let ctx = Self::Context::default();
+            self.validate_with(&ctx).await
+        }
+    }
+
+    /// Validates `Self`, returning an `Err` with an aggregate of all errors if
+    /// the validation failed.
+    ///
+    /// This method should not be implemented manually. Implement [`AsyncValidate::validate_into`] instead,
+    /// because [`AsyncValidate::validate_with`] has a default implementation that calls [`AsyncValidate::validate_into`].
+    fn validate_with(
+        &self,
+        ctx: &Self::Context,
+    ) -> impl Future<Output = Result<(), Report>> + Send {
+        async {
+            let mut report = Report::new();
+            self.validate_into(ctx, &mut Path::empty, &mut report).await;
+            match report.is_empty() {
+                true => Ok(()),
+                false => Err(report),
+            }
+        }
+    }
+
+    /// Validates `Self`, aggregating all validation errors into `Report`.
+    fn validate_into(
+        &self,
+        ctx: &Self::Context,
+        parent: &mut AsyncParentFn,
+        report: &mut Report,
+    ) -> impl Future<Output = ()> + Send;
+}
+
+/// A struct which wraps a potentially invalid instance of some `T`.
+///
+/// Use the `validate` method to turn this type into a `Valid<T>`.
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+#[repr(transparent)]
+pub struct AsyncUnvalidated<T>(T);
+
+impl<T: AsyncValidate> AsyncUnvalidated<T> {
+    /// Creates an `AsyncUnvalidate<T>`
+    pub fn new(v: T) -> Self {
+        Self(v)
+    }
+
+    /// Validates `self`, transforming it into a `Valid<T>`.
+    /// This is the only way to create an instance of `Valid<T>`.
+    pub async fn validate(self) -> Result<Valid<T>, Report>
+    where
+        <T as AsyncValidate>::Context: Default,
+    {
+        self.0.validate().await?;
+        Ok(Valid(self.0))
+    }
+
+    /// Validates `self`, transforming it into a `Valid<T>`.
+    /// This is the only way to create an instance of `Valid<T>`.
+    pub async fn validate_with(
+        self,
+        ctx: &<T as AsyncValidate>::Context,
+    ) -> Result<Valid<T>, Report> {
+        self.0.validate_with(ctx).await?;
+        Ok(Valid(self.0))
+    }
+}
+
+impl<T: AsyncValidate> From<T> for AsyncUnvalidated<T> {
+    fn from(value: T) -> Self {
+        Self(value)
+    }
+}
+
+impl<T: Debug> Debug for AsyncUnvalidated<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Debug::fmt(&self.0, f)
+    }
+}
+
+impl<T: ?Sized + AsyncValidate> AsyncValidate for &T {
+    type Context = T::Context;
+
+    async fn validate_into(
+        &self,
+        ctx: &Self::Context,
+        parent: &mut AsyncParentFn<'_>,
+        report: &mut Report,
+    ) {
+        <T as AsyncValidate>::validate_into(self, ctx, parent, report).await
+    }
+}
+
+impl<T: ?Sized + AsyncValidate> AsyncValidate for &mut T {
+    type Context = T::Context;
+
+    async fn validate_into(
+        &self,
+        ctx: &Self::Context,
+        parent: &mut AsyncParentFn<'_>,
+        report: &mut Report,
+    ) {
+        <T as AsyncValidate>::validate_into(self, ctx, parent, report).await
+    }
+}
+
+impl<T: AsyncValidate> AsyncValidate for std::boxed::Box<T> {
+    type Context = T::Context;
+
+    async fn validate_into(
+        &self,
+        ctx: &Self::Context,
+        parent: &mut AsyncParentFn<'_>,
+        report: &mut Report,
+    ) {
+        <T as AsyncValidate>::validate_into(self, ctx, parent, report).await
+    }
+}
+impl<T: AsyncValidate> AsyncValidate for std::sync::Arc<T> {
+    type Context = T::Context;
+
+    async fn validate_into(
+        &self,
+        ctx: &Self::Context,
+        parent: &mut AsyncParentFn<'_>,
+        report: &mut Report,
+    ) {
+        <T as AsyncValidate>::validate_into(self, ctx, parent, report).await
+    }
+}
+
+impl AsyncValidate for () {
+    type Context = ();
+
+    async fn validate_into(&self, _: &Self::Context, _: &mut AsyncParentFn<'_>, _: &mut Report) {}
+}
+impl<T: AsyncValidate> AsyncValidate for Option<T> {
+    type Context = T::Context;
+
+    async fn validate_into(
+        &self,
+        ctx: &Self::Context,
+        parent: &mut AsyncParentFn<'_>,
+        report: &mut Report,
+    ) {
+        if let Some(value) = self {
+            value.validate_into(ctx, parent, report).await
+        }
+    }
+}

--- a/garde/src/lib.rs
+++ b/garde/src/lib.rs
@@ -1,12 +1,14 @@
 #![doc = include_str!("../README.md")]
 
+pub mod async_validate;
 pub mod error;
 pub mod rules;
 pub mod validate;
 
+pub use async_validate::{AsyncUnvalidated, AsyncValidate};
 pub use error::{Error, Path, Report};
 #[cfg(feature = "derive")]
-pub use garde_derive::{select, Validate};
+pub use garde_derive::{select, AsyncValidate, Validate};
 pub use validate::{Unvalidated, Valid, Validate};
 
 pub type Result = ::core::result::Result<(), Error>;

--- a/garde/src/rules/inner.rs
+++ b/garde/src/rules/inner.rs
@@ -11,6 +11,7 @@
 //! The entrypoint is the [`Inner`] trait. Implementing this trait for a type allows that type to be used with the `#[garde(inner(..))]` rule.
 
 use crate::error::{NoKey, PathComponentKind};
+use std::future::Future;
 
 pub fn apply<T, U, K, F>(field: &T, f: F)
 where
@@ -72,6 +73,85 @@ impl<T> Inner<T> for Option<T> {
     {
         if let Some(item) = self {
             f(item, &NoKey::default())
+        }
+    }
+}
+
+pub async fn async_apply<T, U, K, F>(field: &T, f: F)
+where
+    T: InnerAsync<U, Key = K>,
+    F: AsyncFnMut(&U, &K) -> () + Send,
+    U: Send,
+{
+    // field.validate_inner_async(f).await
+    //FIX: inner async is not implemented, so panic
+    todo!("Inner Async is not supported currently :(");
+}
+
+// Async trait variant
+pub trait InnerAsync<T: Send>: Send + Sync {
+    type Key: PathComponentKind;
+
+    fn validate_inner_async<F, Fut>(&self, f: F) -> impl Future<Output = ()> + Send
+    where
+        F: FnMut(&T, &Self::Key) -> Fut + Send,
+        Fut: Future<Output = ()> + Send;
+}
+
+// Implementation for Vec<T>
+impl<T: std::marker::Send + std::marker::Sync> InnerAsync<T> for Vec<T> {
+    type Key = usize;
+
+    fn validate_inner_async<F, Fut>(&self, f: F) -> impl Future<Output = ()>
+    where
+        F: FnMut(&T, &Self::Key) -> Fut + std::marker::Send,
+        Fut: Future<Output = ()> + std::marker::Send,
+    {
+        async move { self.as_slice().validate_inner_async(f).await }
+    }
+}
+
+// Implementation for [T; N]
+impl<const N: usize, T: std::marker::Send + std::marker::Sync> InnerAsync<T> for [T; N] {
+    type Key = usize;
+
+    fn validate_inner_async<F, Fut>(&self, f: F) -> impl Future<Output = ()> + Send
+    where
+        F: FnMut(&T, &Self::Key) -> Fut + Send,
+        Fut: Future<Output = ()> + Send,
+    {
+        async move {
+            self.as_slice().validate_inner_async(f).await;
+        }
+    }
+}
+
+// Implementation for &[T] - sequential execution
+impl<T: std::marker::Sync + std::marker::Send> InnerAsync<T> for &[T] {
+    type Key = usize;
+
+    async fn validate_inner_async<F, Fut>(&self, mut f: F)
+    where
+        F: FnMut(&T, &Self::Key) -> Fut + Send,
+        Fut: Future<Output = ()> + Send,
+    {
+        for (index, item) in self.iter().enumerate() {
+            f(item, &index).await;
+        }
+    }
+}
+
+// Implementation for Option<T>
+impl<T: std::marker::Sync + std::marker::Send> InnerAsync<T> for Option<T> {
+    type Key = NoKey;
+
+    async fn validate_inner_async<F, Fut>(&self, mut f: F)
+    where
+        F: FnMut(&T, &Self::Key) -> Fut,
+        Fut: Future<Output = ()>,
+    {
+        if let Some(item) = self {
+            f(item, &NoKey::default()).await;
         }
     }
 }

--- a/garde/tests/rules/async_util.rs
+++ b/garde/tests/rules/async_util.rs
@@ -1,0 +1,61 @@
+#![allow(dead_code)]
+
+use std::fmt::{Debug, Write};
+
+use garde::{AsyncValidate};
+use owo_colors::OwoColorize;
+
+pub async fn check_ok<T: AsyncValidate + Debug>(cases: &[T], ctx: &T::Context) {
+    let mut some_failed = false;
+    for case in cases {
+        if let Err(report) = case.validate_with(ctx).await {
+            eprintln!(
+                "{} input: {case:?}, errors: [{}]",
+                "FAIL".red(),
+                report
+                    .to_string()
+                    .split('\n')
+                    .collect::<Vec<_>>()
+                    .join("; ")
+            );
+            some_failed = true;
+        }
+    }
+
+    if some_failed {
+        panic!("some cases failed, see error output");
+    }
+}
+
+#[doc(hidden)]
+pub async fn __check_fail<T: AsyncValidate + Debug>(cases: &[T], ctx: &T::Context) -> String {
+    let mut some_success = false;
+    let mut snapshot = String::new();
+    for case in cases {
+        if let Err(report) = case.validate_with(ctx).await {
+            writeln!(&mut snapshot, "{case:#?}").unwrap();
+            write!(&mut snapshot, "{report}").unwrap();
+            writeln!(&mut snapshot).unwrap();
+        } else {
+            eprintln!("{} input: {case:?}", "SUCCESS".red());
+            some_success = true;
+        }
+    }
+
+    if some_success {
+        panic!("some cases did not fail, see error output");
+    }
+
+    snapshot
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __async_check_fail {
+    ($input:expr, $ctx:expr $(,)?) => {{
+        let snapshot = $crate::rules::async_util::__check_fail($input, $ctx).await;
+        ::insta::assert_snapshot!(snapshot);
+    }};
+}
+
+pub use crate::__async_check_fail as async_check_fail;

--- a/garde/tests/rules/custom_async.rs
+++ b/garde/tests/rules/custom_async.rs
@@ -1,0 +1,120 @@
+use super::async_util;
+use std::time::Duration;
+use tokio::time::sleep;
+
+struct Context {
+    needle: String,
+}
+
+#[derive(Debug, garde::AsyncValidate)]
+#[garde(context(Context as ctx))]
+struct Test<'a> {
+    #[garde(custom(custom_validate_fn))]
+    a: &'a str,
+
+    #[garde(custom(async_custom_validate_b))]
+    b: &'a str,
+
+    #[garde(length(min = ctx.needle.len()))]
+    uses_ctx: &'a str,
+}
+
+
+async fn custom_validate_fn(value: &str, ctx: &Context) -> Result<(), garde::Error> {
+    sleep(Duration::from_millis(5)).await;
+
+    if value != ctx.needle {
+        return Err(garde::Error::new(format!("not equal to {}", ctx.needle)));
+    }
+    Ok(())
+}
+
+async fn async_custom_validate_b(value: &str, ctx: &Context) -> Result<(), garde::Error> {
+    sleep(Duration::from_millis(5)).await;
+
+    if value != ctx.needle {
+        return Err(garde::Error::new(format!(
+            "`b` is not equal to {}",
+            ctx.needle
+        )));
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn custom_valid() {
+    let ctx = Context {
+        needle: "test".into(),
+    };
+
+    async_util::check_ok(
+        &[Test {
+            a: "test",
+            b: "test",
+            uses_ctx: "test",
+        }],
+        &ctx,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn custom_invalid() {
+    let ctx = Context {
+        needle: "test".into(),
+    };
+
+    async_util::async_check_fail!(
+        &[Test {
+            a: "asdf",
+            b: "asdf",
+            uses_ctx: "",
+        }],
+        &ctx
+    );
+}
+
+//
+// Multi tests
+//
+
+#[derive(Debug, garde::AsyncValidate)]
+#[garde(context(Context))]
+struct Multi<'a> {
+    #[garde(custom(custom_validate_fn), custom(custom_validate_fn))]
+    field: &'a str,
+
+    // #[garde(inner(custom(custom_validate_fn), custom(custom_validate_fn)))]
+    // inner: &'a [&'a str],
+}
+
+#[tokio::test]
+async fn multi_custom_valid() {
+    let ctx = Context {
+        needle: "test".into(),
+    };
+
+    async_util::check_ok(
+        &[Multi {
+            field: "test",
+            // inner: &["test"],
+        }],
+        &ctx,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn multi_custom_invalid() {
+    let ctx = Context {
+        needle: "test".into(),
+    };
+
+    async_util::async_check_fail!(
+        &[Multi {
+            field: "asdf",
+            // inner: &["asdf"],
+        }],
+        &ctx
+    );
+}

--- a/garde/tests/rules/mod.rs
+++ b/garde/tests/rules/mod.rs
@@ -24,5 +24,7 @@ mod select;
 mod skip;
 mod suffix;
 mod url;
+mod custom_async;
 
 mod util;
+mod async_util;

--- a/garde/tests/rules/snapshots/rules__rules__custom_async__custom_invalid.snap
+++ b/garde/tests/rules/snapshots/rules__rules__custom_async__custom_invalid.snap
@@ -1,0 +1,12 @@
+---
+source: garde/tests/./rules/custom_async.rs
+expression: snapshot
+---
+Test {
+    a: "asdf",
+    b: "asdf",
+    uses_ctx: "",
+}
+a: not equal to test
+b: `b` is not equal to test
+uses_ctx: length is lower than 4

--- a/garde/tests/rules/snapshots/rules__rules__custom_async__multi_custom_invalid.snap
+++ b/garde/tests/rules/snapshots/rules__rules__custom_async__multi_custom_invalid.snap
@@ -1,0 +1,9 @@
+---
+source: garde/tests/./rules/custom_async.rs
+expression: snapshot
+---
+Multi {
+    field: "asdf",
+}
+field: not equal to test
+field: not equal to test

--- a/garde/tests/ui/compile-fail/non_unary_newtype.stderr
+++ b/garde/tests/ui/compile-fail/non_unary_newtype.stderr
@@ -2,22 +2,22 @@ error: transparent structs must have exactly one field
  --> tests/ui/compile-fail/non_unary_newtype.rs
   |
   | #[garde(transparent)]
-  | ^
+  | ^^^^^^^^^^^^^^^^^^^^^
 
 error: transparent structs must have exactly one field
  --> tests/ui/compile-fail/non_unary_newtype.rs
   |
   | #[garde(transparent)]
-  | ^
+  | ^^^^^^^^^^^^^^^^^^^^^
 
 error: transparent structs must have exactly one field
  --> tests/ui/compile-fail/non_unary_newtype.rs
   |
   | #[garde(transparent)]
-  | ^
+  | ^^^^^^^^^^^^^^^^^^^^^
 
 error: transparent structs must have exactly one field
  --> tests/ui/compile-fail/non_unary_newtype.rs
   |
   | #[garde(transparent)]
-  | ^
+  | ^^^^^^^^^^^^^^^^^^^^^

--- a/garde/tests/ui/compile-pass/custom.rs
+++ b/garde/tests/ui/compile-pass/custom.rs
@@ -40,7 +40,7 @@ impl<T: garde::Validate> garde::Validate for MyVec<T> {
     fn validate_into(
         &self,
         ctx: &Self::Context,
-        mut path: &mut dyn FnMut() -> garde::Path,
+        mut path: &mut garde::validate::ParentFn,
         report: &mut garde::Report,
     ) {
         for (index, item) in self.0.iter().enumerate() {

--- a/garde_derive/src/check.rs
+++ b/garde_derive/src/check.rs
@@ -1,14 +1,15 @@
 use std::collections::BTreeSet;
+use std::marker::PhantomData;
 
 use proc_macro2::Span;
 use syn::parse_quote;
 use syn::spanned::Spanned;
 
-use crate::model;
 use crate::model::LengthMode;
 use crate::util::{default_ctx_name, MaybeFoldError};
+use crate::{model, ValidationMode};
 
-pub fn check(input: model::Input) -> syn::Result<model::Validate> {
+pub fn check<M: ValidationMode>(input: model::Input) -> syn::Result<model::Validate<M>> {
     let model::Input {
         ident,
         generics,
@@ -77,12 +78,13 @@ pub fn check(input: model::Input) -> syn::Result<model::Validate> {
         return Err(error);
     }
 
-    Ok(model::Validate {
+    Ok(model::Validate::<M> {
         ident,
         generics,
         context,
         is_transparent: transparent.is_some(),
         kind,
+        _mode: PhantomData,
         options,
     })
 }

--- a/garde_derive/src/check.rs
+++ b/garde_derive/src/check.rs
@@ -85,7 +85,6 @@ pub fn check<M: ValidationMode>(input: model::Input) -> syn::Result<model::Valid
         is_transparent: transparent.is_some(),
         kind,
         _mode: PhantomData,
-        options,
     })
 }
 

--- a/garde_derive/src/lib.rs
+++ b/garde_derive/src/lib.rs
@@ -1,6 +1,5 @@
 mod check;
 mod emit;
-mod fields;
 mod model;
 mod syntax;
 mod util;

--- a/garde_derive/src/lib.rs
+++ b/garde_derive/src/lib.rs
@@ -1,5 +1,6 @@
 mod check;
 mod emit;
+mod fields;
 mod model;
 mod syntax;
 mod util;
@@ -7,6 +8,62 @@ mod util;
 use proc_macro::{Delimiter, Literal, Span, TokenStream, TokenTree};
 use quote::quote;
 use syn::DeriveInput;
+use syn::__private::TokenStream2;
+
+trait ValidationMode {
+    fn await_token() -> TokenStream2;
+    fn validate_path() -> TokenStream2;
+    fn async_token() -> TokenStream2;
+
+    fn parent_fn_path() -> TokenStream2;
+    fn apply_fn_iden() -> TokenStream2;
+}
+
+struct SyncMarker;
+struct AsyncMarker;
+
+impl ValidationMode for SyncMarker {
+    fn await_token() -> TokenStream2 {
+        TokenStream2::new()
+    }
+
+    fn validate_path() -> TokenStream2 {
+        quote!(::garde::validate::Validate)
+    }
+
+    fn async_token() -> TokenStream2 {
+        TokenStream2::new()
+    }
+
+    fn parent_fn_path() -> TokenStream2 {
+        quote!(::garde::validate::ParentFn)
+    }
+
+    fn apply_fn_iden() -> TokenStream2 {
+        quote!(apply)
+    }
+}
+
+impl ValidationMode for AsyncMarker {
+    fn await_token() -> TokenStream2 {
+        quote!(.await)
+    }
+
+    fn validate_path() -> TokenStream2 {
+        quote!(::garde::async_validate::AsyncValidate)
+    }
+
+    fn async_token() -> TokenStream2 {
+        quote!(async)
+    }
+    fn parent_fn_path() -> TokenStream2 {
+        quote!(::garde::async_validate::AsyncParentFn<'_>)
+    }
+
+    fn apply_fn_iden() -> TokenStream2 {
+        quote!(async_apply)
+    }
+}
 
 #[proc_macro_derive(Validate, attributes(garde))]
 pub fn derive_validate(input: TokenStream) -> TokenStream {
@@ -15,11 +72,25 @@ pub fn derive_validate(input: TokenStream) -> TokenStream {
         Ok(v) => v,
         Err(e) => return e.into_compile_error().into(),
     };
-    let input = match check::check(input) {
+    let input = match check::check::<SyncMarker>(input) {
         Ok(v) => v,
         Err(e) => return e.into_compile_error().into(),
     };
-    emit::emit(input).into()
+    emit::emit::<SyncMarker>(input).into()
+}
+
+#[proc_macro_derive(AsyncValidate, attributes(garde))]
+pub fn derive_async_validate(input: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(input as DeriveInput);
+    let input = match syntax::parse(input) {
+        Ok(v) => v,
+        Err(e) => return e.into_compile_error().into(),
+    };
+    let input = match check::check::<AsyncMarker>(input) {
+        Ok(v) => v,
+        Err(e) => return e.into_compile_error().into(),
+    };
+    emit::emit::<AsyncMarker>(input).into()
 }
 
 #[proc_macro]

--- a/garde_derive/src/model.rs
+++ b/garde_derive/src/model.rs
@@ -164,10 +164,6 @@ pub struct Validate<M: ValidationMode> {
     pub is_transparent: bool,
     pub kind: ValidateKind,
     pub _mode: PhantomData<M>,
-    // I don't know why Rust thinks this is unused.
-    // It's both read and written, grep for `.allow_unvalidated`.
-    #[allow(dead_code)]
-    pub options: Options,
 }
 
 pub struct Options {

--- a/garde_derive/src/model.rs
+++ b/garde_derive/src/model.rs
@@ -1,7 +1,10 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::marker::PhantomData;
 
 use proc_macro2::{Ident, Span};
 use syn::{Expr, Generics, Path, Type};
+
+use crate::ValidationMode;
 
 pub struct Input {
     pub ident: Ident,
@@ -154,12 +157,13 @@ pub struct List<T> {
     pub contents: Vec<T>,
 }
 
-pub struct Validate {
+pub struct Validate<M: ValidationMode> {
     pub ident: Ident,
     pub generics: Generics,
     pub context: (Type, Ident),
     pub is_transparent: bool,
     pub kind: ValidateKind,
+    pub _mode: PhantomData<M>,
     // I don't know why Rust thinks this is unused.
     // It's both read and written, grep for `.allow_unvalidated`.
     #[allow(dead_code)]


### PR DESCRIPTION
# Work in Progress: Experimental Async Support

Async validation was deemed out of scope by the maintainer (see jprochazk/garde#83). This PR is an experimental async implementation.

### Status

* Early stage; minimal testing so far.
* Some core functional (`inner`) is not supported

### Notes

* `Inner` does not currently work with async.
* Implementation either relies on generics or duplicates parts of the sync validation logic, which may introduce maintenance issues.
* The sync implementation is essentially unchanged; only the parent function now uses the ParentFn type.
* Removed unused code:

  ```rust
  #[allow(dead_code)]
  pub options: Options,
  ```

Feedback would be helpful.
