### PR TITLE
Added field rename capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A Rust validation library
 - [Length modes](#length-modes)
 - [Inner type validation](#inner-type-validation)
 - [Newtypes](#newtypes)
+- [Renaming fields](#renaming-fields)
 - [Handling Option](#handling-option)
 - [Custom validation](#custom-validation)
 - [Context/Self access](#contextself-access)
@@ -271,6 +272,52 @@ User {
 ```
 
 Structs with the `#[garde(transparent)]` attribute may have more than one field, but there must be only one unskipped field. That means every field other than the one you wish to validate must be `#[garde(skip)]`.
+
+
+### Renaming fields
+
+You may rename a struct field using the `rename` attribute. This will change the name of the field
+in the generated report.
+
+```rust,ignore
+User {
+  #[garde(rename("userName"))]
+  usr: Username("")
+}.validate()
+
+"userName: length is lower than 3"
+```
+
+This can be done for tuples as well, which is helpful when you want to name enum variants since garde does
+not include enum variant names in the report path.
+
+```rust,ignore
+#[derive(Debug, garde::Validate)]
+enum LegalEntity {
+    LLC(
+        #[garde(length(min = 3, max = 100))]
+        #[garde(rename("Business"))]
+        String
+    ),
+    Trust(
+        #[garde(length(min = 3, max = 100))]
+        #[garde(rename("Trust"))]
+        String
+    )
+    Corp(
+        #[garde(length(min = 10, max = 100))]
+        #[garde(rename("Corporation"))]
+        String
+    )
+}
+
+LegalEntity::LLC("a").validate()
+"Business: length is lower than 3"
+
+LegalEntity::Trust("a").validate()
+"Trust: length is lower than 3"
+```
+
 
 ### Handling Option
 

--- a/garde/tests/rules/mod.rs
+++ b/garde/tests/rules/mod.rs
@@ -20,6 +20,7 @@ mod pattern;
 mod phone_number;
 mod prefix;
 mod range;
+mod rename;
 mod select;
 mod skip;
 mod suffix;

--- a/garde/tests/rules/rename.rs
+++ b/garde/tests/rules/rename.rs
@@ -1,0 +1,38 @@
+use garde::{Error, Path, Validate};
+
+
+#[derive(Debug, garde::Validate)]
+struct Test<'a> {
+    #[garde(length(min = 10, max = 100))]
+    #[garde(rename("public_name"))]
+    private_name: &'a str,
+    #[garde(dive)]
+    #[garde(rename("public_enum"))]
+    my_enum: TestEnum<'a>
+}
+
+#[derive(Debug, garde::Validate)]
+enum TestEnum<'a> {
+    PrivA(
+        #[garde(length(min = 10, max = 100))]
+        #[garde(rename("public_variant"))]
+        &'a str
+    )
+}
+
+
+#[test]
+fn renaming_works() {
+    let test = Test {
+        private_name: &"asdf",
+        my_enum: TestEnum::PrivA("asdf")
+    };
+
+    assert_eq!(
+        test.validate().unwrap_err().into_inner(),
+        vec![
+            (Path::new("public_enum").join("public_variant"), Error::new("length is lower than 10")),
+            (Path::new("public_name"), Error::new("length is lower than 10")),
+        ]
+    );
+}


### PR DESCRIPTION
A rename attribute was already present and was being parsed. The only missing link was substituting the field key in the case of structs and the field index in the case of tuples with the alias provided by the rename attribute.

Added a test that verifies the renaming works.

Also added a new section to the README that showcases how to use the rename feature.

Wanted to refactor the rename attribute to work as serde (i.e. #[garde(rename = "name")] ) instead of #[garde(rename("name"))], but did not have the time or expertise to get into it that deep.

Couldn't have done it without the guidance in #127, thank you!