### PR TITLE
Fix validate_with example

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ The context may be any type without generic parameters. By default, the context 
 ```rust,ignore
 #[derive(garde::Validate)]
 struct Metadata {
+    #[garde(ascii)]
     name: String,
 }
 
@@ -316,7 +317,9 @@ struct PasswordContext {
 }
 
 fn is_strong_password(value: &str, context: &PasswordContext) -> garde::Result {
-    let bits = context.entropy.estimate_password_entropy(value.as_bytes())
+    let bits = context
+        .entropy
+        .estimate_password_entropy(value.as_bytes())
         .map(|e| e.mask_entropy)
         .unwrap_or(0.0);
     if bits < context.min_entropy {
@@ -325,9 +328,17 @@ fn is_strong_password(value: &str, context: &PasswordContext) -> garde::Result {
     Ok(())
 }
 
-let ctx = PasswordContext { /* ... */ };
-let user = User { /* ... */ };
-user.validate_with(&ctx)?;
+let ctx = PasswordContext {
+    min_entropy: 30.0,
+    entropy: cracken::password_entropy::EntropyEstimator::new(),
+};
+let user = User {
+    password: "weakpassword".to_string(),
+    metadata: Metadata {
+        name: "validname".to_string(),
+    },
+};
+user.validate_with(&ctx).unwrap();
 ```
 
 The validator function may accept the value as a reference to any type which it derefs to.

--- a/README.md
+++ b/README.md
@@ -297,10 +297,17 @@ The context may be any type without generic parameters. By default, the context 
 
 ```rust,ignore
 #[derive(garde::Validate)]
+struct Metadata {
+    name: String,
+}
+
+#[derive(garde::Validate)]
 #[garde(context(PasswordContext))]
 struct User {
     #[garde(custom(is_strong_password))]
     password: String,
+    #[garde(dive(&()))]
+    metadata: Metadata,
 }
 
 struct PasswordContext {
@@ -320,7 +327,7 @@ fn is_strong_password(value: &str, context: &PasswordContext) -> garde::Result {
 
 let ctx = PasswordContext { /* ... */ };
 let user = User { /* ... */ };
-user.validate(&ctx)?;
+user.validate_with(&ctx)?;
 ```
 
 The validator function may accept the value as a reference to any type which it derefs to.


### PR DESCRIPTION
I came across the discussion in https://github.com/jprochazk/garde/discussions/152 after having the same problem. 
So I fixed it in the readme and extended it with how to use normal context in other parts. 

To prevent them in the future maybe use rust examples or remove the `ignore` in the codeblocks so the examples are at least compile validated?