### PR TITLE
chore: bump phonenumber to 0.3.9+9.0.21

### DIFF
--- a/garde/Cargo.toml
+++ b/garde/Cargo.toml
@@ -37,7 +37,7 @@ email = ["regex"]
 email-idna = ["dep:idna"]
 regex = ["dep:regex", "dep:once_cell", "garde_derive?/regex"]
 # for backward compatibility with <0.14.0
-pattern = ["regex"]                      
+pattern = ["regex"]
 js-sys = ["dep:js-sys", "garde_derive?/js-sys"]
 rust_decimal = ["dep:rust_decimal"]
 
@@ -49,7 +49,7 @@ card-validate = { version = "2.3", optional = true }
 compact_str = { version = "0.8.0", default-features = false }
 idna = { version = "1", optional = true }
 once_cell = { version = "1", optional = true }
-phonenumber = { version = "0.3.6+8.13.36", optional = true }
+phonenumber = { version = "0.3.9+9.0.21", optional = true }
 regex = { version = "1", default-features = false, features = ["std"], optional = true }
 rust_decimal = { version = "1", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }


### PR DESCRIPTION
This PR is meant to upgrade the phonenumber crate because it used to depend on bincode, but bincode is now unmaintained: https://rustsec.org/advisories/RUSTSEC-2025-0141