### PR TITLE
implement `AsStr` for `compact_str::CompactString`

### DIFF
--- a/garde/Cargo.toml
+++ b/garde/Cargo.toml
@@ -46,7 +46,7 @@ rust_decimal = ["dep:rust_decimal"]
 garde_derive = { workspace = true, optional = true, default-features = false }
 
 card-validate = { version = "2.3", optional = true }
-compact_str = { version = "0.8.0", default-features = false }
+compact_str = { version = "0.9.0", default-features = false }
 idna = { version = "1", optional = true }
 once_cell = { version = "1", optional = true }
 phonenumber = { version = "0.3.6+8.13.36", optional = true }

--- a/garde/Cargo.toml
+++ b/garde/Cargo.toml
@@ -46,7 +46,7 @@ rust_decimal = ["dep:rust_decimal"]
 garde_derive = { workspace = true, optional = true, default-features = false }
 
 card-validate = { version = "2.3", optional = true }
-compact_str = { version = "0.9.0", default-features = false }
+compact_str = { version = "^0.9.0", default-features = false }
 idna = { version = "1", optional = true }
 once_cell = { version = "1", optional = true }
 phonenumber = { version = "0.3.6+8.13.36", optional = true }

--- a/garde/src/rules/length/bytes.rs
+++ b/garde/src/rules/length/bytes.rs
@@ -42,6 +42,7 @@ macro_rules! impl_via_len {
 }
 
 impl_via_len!(std::string::String);
+impl_via_len!(compact_str::CompactString);
 impl_via_len!(in<'a> &'a std::string::String);
 impl_via_len!(in<'a> &'a str);
 impl_via_len!(in<'a> std::borrow::Cow<'a, str>);

--- a/garde/src/rules/length/chars.rs
+++ b/garde/src/rules/length/chars.rs
@@ -42,6 +42,7 @@ macro_rules! impl_via_chars {
 }
 
 impl_via_chars!(std::string::String);
+impl_via_chars!(compact_str::CompactString);
 impl_via_chars!(in<'a> &'a std::string::String);
 impl_via_chars!(in<'a> &'a str);
 impl_via_chars!(in<'a> std::borrow::Cow<'a, str>);

--- a/garde/src/rules/length/graphemes.rs
+++ b/garde/src/rules/length/graphemes.rs
@@ -44,6 +44,7 @@ macro_rules! impl_str {
 }
 
 impl_str!(std::string::String);
+impl_str!(compact_str::CompactString);
 impl_str!(in<'a> &'a std::string::String);
 impl_str!(in<'a> &'a str);
 impl_str!(in<'a> std::borrow::Cow<'a, str>);

--- a/garde/src/rules/length/simple.rs
+++ b/garde/src/rules/length/simple.rs
@@ -44,6 +44,7 @@ macro_rules! impl_via_bytes {
 }
 
 impl_via_bytes!(std::string::String);
+impl_via_bytes!(compact_str::CompactString);
 impl_via_bytes!(in<'a> &'a std::string::String);
 impl_via_bytes!(in<'a> &'a str);
 impl_via_bytes!(in<'a> std::borrow::Cow<'a, str>);

--- a/garde/src/rules/length/utf16.rs
+++ b/garde/src/rules/length/utf16.rs
@@ -40,6 +40,7 @@ macro_rules! impl_str {
 }
 
 impl_str!(std::string::String);
+impl_str!(compact_str::CompactString);
 impl_str!(in<'a> &'a std::string::String);
 impl_str!(in<'a> &'a str);
 impl_str!(in<'a> std::borrow::Cow<'a, str>);

--- a/garde/src/rules/mod.rs
+++ b/garde/src/rules/mod.rs
@@ -37,6 +37,12 @@ impl AsStr for String {
     }
 }
 
+impl AsStr for compact_str::CompactString {
+    fn as_str(&self) -> &str {
+        compact_str::CompactString::as_str(self)
+    }
+}
+
 impl AsStr for std::borrow::Cow<'_, str> {
     fn as_str(&self) -> &str {
         std::borrow::Cow::as_ref(self)


### PR DESCRIPTION
This very basic PR adds an impl for `AsStr` for `compact_str::CompactString`, while its not the best solution to manually add types to the trait like this, this type is used by garde itself already and would not hurt to have an impl for.