### PR TITLE
Fix derive for tuple structs with `#[skip]`

### DIFF
--- a/garde/tests/rules/skip.rs
+++ b/garde/tests/rules/skip.rs
@@ -21,9 +21,27 @@ enum Enum {
     Tuple(#[garde(skip)] u64),
 }
 
+#[derive(Debug, garde::Validate)]
+struct Inner(#[garde(ascii)] String);
+
+#[allow(dead_code)]
+#[derive(Debug, garde::Validate)]
+enum SkipBeforeDive {
+    Variant(#[garde(skip)] u64, #[garde(dive)] Inner),
+}
+
 #[test]
 fn skip_valid() {
     util::check_ok(&[Struct { field: 50 }], &());
     util::check_ok(&[Tuple(50)], &());
     util::check_ok(&[Enum::Struct { field: 50 }, Enum::Tuple(50)], &());
+    util::check_ok(&[SkipBeforeDive::Variant(1, Inner("ascii".into()))], &());
+}
+
+#[test]
+fn skip_before_dive_validates_correct_field() {
+    util::check_fail!(
+        &[SkipBeforeDive::Variant(1, Inner("not ascii: 😀".into()))],
+        &()
+    );
 }

--- a/garde/tests/rules/snapshots/rules__rules__skip__skip_before_dive_validates_correct_field.snap
+++ b/garde/tests/rules/snapshots/rules__rules__skip__skip_before_dive_validates_correct_field.snap
@@ -1,0 +1,11 @@
+---
+source: garde/tests/./rules/skip.rs
+expression: snapshot
+---
+Variant(
+    1,
+    Inner(
+        "not ascii: 😀",
+    ),
+)
+[1][0]: not ascii

--- a/garde_derive/src/emit.rs
+++ b/garde_derive/src/emit.rs
@@ -496,19 +496,15 @@ impl ToTokens for Bindings<'_> {
                 quote!( { #(#names,)* #rest } )
             }
             model::ValidateVariant::Tuple(fields) => {
-                let indices = fields
-                    .iter()
-                    .enumerate()
-                    .filter(|(_, field)| field.skip.is_none())
-                    .map(|(i, _)| IndexBinding(i))
-                    .collect::<Vec<_>>();
-                let rest = if indices.len() != fields.len() {
-                    Some(quote!(..))
-                } else {
-                    None
-                };
+                let bindings = fields.iter().enumerate().map(|(i, field)| {
+                    if field.skip.is_none() {
+                        IndexBinding(i).to_token_stream()
+                    } else {
+                        quote!(_)
+                    }
+                });
 
-                quote!( ( #(#indices,)* #rest ) )
+                quote!( ( #(#bindings,)* ) )
             }
         }
         .to_tokens(tokens)


### PR DESCRIPTION
- Closes #159