### PR TITLE
Exclude `pattern_mismatched_types` on stable instead of pinned

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,10 +75,10 @@ jobs:
         include:
           - build: pinned
             rust: 1.87.0
-            EXCLUDE_UI_TESTS: "pattern_mismatched_types"
+            EXCLUDE_UI_TESTS: ""
           - build: stable
             rust: stable
-            EXCLUDE_UI_TESTS: ""
+            EXCLUDE_UI_TESTS: "pattern_mismatched_types"
           - build: nightly
             rust: nightly
             EXCLUDE_UI_TESTS: "pattern_mismatched_types,non_unary_newtype"

--- a/garde/tests/ui/compile-fail/pattern_mismatched_types.stderr
+++ b/garde/tests/ui/compile-fail/pattern_mismatched_types.stderr
@@ -7,14 +7,10 @@ error[E0277]: the trait bound `&str: Matcher` is not satisfied
   |     #[garde(pattern(STR))]
   |                     ^^^ the trait `Matcher` is not implemented for `&str`
   |
-help: the following other types implement trait `Matcher`
- --> src/rules/pattern.rs
-  |
-  | impl<T: Matcher> Matcher for std::sync::LazyLock<T> {
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `LazyLock<T>`
-...
-  |     impl<T: Matcher> Matcher for once_cell::sync::Lazy<T> {
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `once_cell::sync::Lazy<T>`
+  = help: the following other types implement trait `Matcher`:
+            LazyLock<T>
+            Regex
+            once_cell::sync::Lazy<T>
 note: required by a bound in `garde::rules::pattern::apply`
  --> src/rules/pattern.rs
   |


### PR DESCRIPTION
This way the test passes locally if running with Rust version pinned in `rust-toolchain`.